### PR TITLE
Gas Optimization / Phase 1

### DIFF
--- a/contracts/carbon/Strategies.sol
+++ b/contracts/carbon/Strategies.sol
@@ -422,13 +422,13 @@ abstract contract Strategies is Initializable {
 
             // emit update events if necessary
             Token[2] memory sortedTokens = _sortStrategyTokens(params.pool, ordersInverted);
-                emit StrategyUpdated({
-                    id: strategyId,
-                    token0: sortedTokens[0],
-                    token1: sortedTokens[1],
-                    order0: orders[0],
-                    order1: orders[1]
-                });
+            emit StrategyUpdated({
+                id: strategyId,
+                token0: sortedTokens[0],
+                token1: sortedTokens[1],
+                order0: orders[0],
+                order1: orders[1]
+            });
 
             totals.sourceAmount += tempTradeAmounts.sourceAmount;
             totals.targetAmount += tempTradeAmounts.targetAmount;

--- a/test/carbon/trading/trading.ts
+++ b/test/carbon/trading/trading.ts
@@ -74,7 +74,7 @@ const permutations: FactoryOptions[] = [
     { sourceSymbol: TokenSymbol.TKN0, targetSymbol: TokenSymbol.TKN1, byTargetAmount: false, inverseOrders: false }
 ];
 
-describe.only('Trading', () => {
+describe('Trading', () => {
     let deployer: SignerWithAddress;
     let marketMaker: SignerWithAddress;
     let trader: SignerWithAddress;
@@ -197,7 +197,6 @@ describe.only('Trading', () => {
         });
         const receipt = await tx.wait();
         gasUsed = gasUsed.add(receipt.gasUsed.mul(receipt.effectiveGasPrice));
-        console.log(receipt.gasUsed.toString());
 
         // prepare variables for assertions
         const tradingFeeAmount = getTradingFeeAmount(byTargetAmount, sourceAmount, targetAmount);


### PR DESCRIPTION
1. Get rid of the redundant return-value in function `_updateOrders`
2. Reduce the number of access-via-index read operations into the `orders` array
3. Get rid of the redundant 'strategyUpdated' mechanism (since a strategy is always updated during trades)

This reduces about 550 gas per strategy per trade, and slightly cleans the code (bullet 3 above).