### PR TITLE
Unchecked MathEx

### DIFF
--- a/contracts/utility/MathEx.sol
+++ b/contracts/utility/MathEx.sol
@@ -108,7 +108,7 @@ library MathEx {
         // approximate the root of `f(x) = 1 / x - d` using the newton–raphson convergence method
         uint256 x = 1;
         unchecked {
-            // safe because no `i < 8`
+            // safe because `i < 8`
             for (uint256 i = 0; i < 8; i++) {
                 x = _unsafeMul(x, _unsafeSub(2, _unsafeMul(x, d))); // `x = x * (2 - x * d) mod 2 ^ 256`
             }


### PR DESCRIPTION
**Please review this PR in GitHub's Dev Browser (by clicking `.`)**.

Added `unchecked` for trivial cases in the MathEx library functions:
1. In functions with no `+` or `-` or `*`, but with `/` (which cost less when unchecked)
2. In cases of `x + 1`, when it is known that `x < type(uint256).max`
3. In cases of `x - y`, when it is known that `x >= y`

Note that there is no technical difference between using `unchecked` and calling the `_unsafe` functions (other than the extra function call in the latter case).

We use the `_unsafe` functions when the reason is 2s-complement arithmetic (deliberate overflows).
We use `unchecked` (added in this PR) when the reason is strictly gas optimization.