### PR TITLE
Implement `MathEx.minFactor` and use it during trade calculation

### DIFF
--- a/contracts/carbon/Strategies.sol
+++ b/contracts/carbon/Strategies.sol
@@ -708,8 +708,8 @@ abstract contract Strategies is Initializable {
         uint256 temp2 = y * A + z * B;
         uint256 temp3 = temp2 * x;
 
-        uint256 factor1 = MathEx.mulDivC(temp1, temp1, type(uint256).max);
-        uint256 factor2 = MathEx.mulDivC(temp3, A, type(uint256).max);
+        uint256 factor1 = MathEx.minFactor(temp1, temp1);
+        uint256 factor2 = MathEx.minFactor(temp3, A);
         uint256 factor = MathUpgradeable.max(factor1, factor2);
 
         uint256 temp4 = MathEx.mulDivC(temp1, temp1, factor);
@@ -740,8 +740,8 @@ abstract contract Strategies is Initializable {
         uint256 temp2 = y * A + z * B;
         uint256 temp3 = temp2 - x * A;
 
-        uint256 factor1 = MathEx.mulDivC(temp1, temp1, type(uint256).max);
-        uint256 factor2 = MathEx.mulDivC(temp2, temp3, type(uint256).max);
+        uint256 factor1 = MathEx.minFactor(temp1, temp1);
+        uint256 factor2 = MathEx.minFactor(temp2, temp3);
         uint256 factor = MathUpgradeable.max(factor1, factor2);
 
         uint256 temp4 = MathEx.mulDivC(temp1, temp1, factor);

--- a/contracts/helpers/TestMathEx.sol
+++ b/contracts/helpers/TestMathEx.sol
@@ -11,4 +11,8 @@ contract TestMathEx {
     function mulDivC(uint256 x, uint256 y, uint256 z) external pure returns (uint256) {
         return MathEx.mulDivC(x, y, z);
     }
+
+    function minFactor(uint256 x, uint256 y) external pure returns (uint256) {
+        return MathEx.minFactor(x, y);
+    }
 }

--- a/test/utility/MathEx.ts
+++ b/test/utility/MathEx.ts
@@ -16,7 +16,7 @@ describe('MathEx', () => {
         mathContract = await Contracts.TestMathEx.deploy();
     });
 
-    const testMulDiv = (x: BigNumber, y: BigNumber, z: BigNumber) => {
+    const test = (x: BigNumber, y: BigNumber, z: BigNumber) => {
         for (const funcName in mulDivFuncs) {
             it(`${funcName}(${x}, ${y}, ${z})`, async () => {
                 const expectedFunc = (mulDivFuncs as any)[funcName];
@@ -27,6 +27,18 @@ describe('MathEx', () => {
                     expect(actual).to.equal(expected);
                 } else {
                     await expect(actualFunc(x, y, z)).to.be.revertedWithError('Overflow');
+                }
+            });
+        }
+
+        const tuples = [[x, y], [x, z], [y, z], [x, y.add(z)], [x.add(z), y], [x.add(z), y.add(z)]];
+        const values = tuples.filter((tuple) => tuple.every((value) => value.lte(MAX_UINT256)));
+        for (const [x, y] of values) {
+            it(`minFactor(${x}, ${y})`, async () => {
+                const actual = await mathContract.minFactor(x, y);
+                expect(mulDivFuncs.mulDivC(x, y, actual)).to.be.lte(MAX_UINT256);
+                if (actual.gt(1)) {
+                    expect(mulDivFuncs.mulDivC(x, y, actual.sub(1))).to.be.gt(MAX_UINT256);
                 }
             });
         }
@@ -42,7 +54,7 @@ describe('MathEx', () => {
                                 const x = BigNumber.from(2).pow(px).div(ax);
                                 const y = BigNumber.from(2).pow(py).div(ay);
                                 const z = BigNumber.from(2).pow(pz).div(az);
-                                testMulDiv(x, y, z);
+                                test(x, y, z);
                             }
                         }
                     }
@@ -61,7 +73,7 @@ describe('MathEx', () => {
                                 const x = BigNumber.from(2).pow(px).add(ax);
                                 const y = BigNumber.from(2).pow(py).add(ay);
                                 const z = BigNumber.from(2).pow(pz).add(az);
-                                testMulDiv(x, y, z);
+                                test(x, y, z);
                             }
                         }
                     }
@@ -78,7 +90,7 @@ describe('MathEx', () => {
                                 const x = BigNumber.from(2).pow(px).sub(ax);
                                 const y = BigNumber.from(2).pow(py).sub(ay);
                                 const z = BigNumber.from(2).pow(pz).sub(az);
-                                testMulDiv(x, y, z);
+                                test(x, y, z);
                             }
                         }
                     }
@@ -95,7 +107,7 @@ describe('MathEx', () => {
                                 const x = BigNumber.from(2).pow(px).div(ax);
                                 const y = BigNumber.from(2).pow(py).div(ay);
                                 const z = BigNumber.from(2).pow(pz).div(az);
-                                testMulDiv(x, y, z);
+                                test(x, y, z);
                             }
                         }
                     }


### PR DESCRIPTION
Handle issue #75, and reduce trading cost by ~500 gas per order.

Also, though not directly related, improve private function `_mul512` performance, by unchecking a safe subtraction.