### PR TITLE
When both rates are 0, prevent only trading

### DIFF
--- a/contracts/carbon/Strategies.sol
+++ b/contracts/carbon/Strategies.sol
@@ -137,7 +137,7 @@ abstract contract Strategies is Initializable {
     error InvalidRate();
     error InvalidTradeActionStrategyId();
     error InvalidTradeActionAmount();
-    error StrategyDoesNotExist();
+    error OrderDisabled();
     error OutDated();
 
     struct SourceAndTargetAmounts {
@@ -701,6 +701,9 @@ abstract contract Strategies is Initializable {
         uint256 B
     ) private pure returns (uint256) {
         if (A == 0) {
+            if (B == 0) {
+                revert OrderDisabled();
+            }
             return MathEx.mulDivF(x, B * B, ONE * ONE);
         }
 
@@ -733,6 +736,9 @@ abstract contract Strategies is Initializable {
         uint256 B
     ) private pure returns (uint256) {
         if (A == 0) {
+            if (B == 0) {
+                revert OrderDisabled();
+            }
             return MathEx.mulDivC(x, ONE * ONE, B * B);
         }
 
@@ -773,9 +779,6 @@ abstract contract Strategies is Initializable {
     function _unpackOrders(
         uint256[3] memory values
     ) private pure returns (Order[2] memory orders, bool ordersInverted) {
-        if (values[0] == 0 && values[1] == 0 && values[2] == 0) {
-            revert StrategyDoesNotExist();
-        }
         orders = [
             Order({
                 y: uint128(values[0] >> 0),

--- a/test/carbon/trading/trading.ts
+++ b/test/carbon/trading/trading.ts
@@ -517,7 +517,7 @@ describe('Trading', () => {
             }
         });
 
-        describe('reverts if tradeActions provided with strategyIds that do not exist', () => {
+        describe('reverts if attempting to trade on a disabled order', () => {
             const permutations = [{ byTargetAmount: false }, { byTargetAmount: true }];
             for (const { byTargetAmount } of permutations) {
                 it(`byTargetAmount: ${byTargetAmount}`, async () => {
@@ -529,10 +529,14 @@ describe('Trading', () => {
                     });
                     const { strategies, sourceAmount, tradeActions, targetAmount, sourceSymbol, targetSymbol } =
                         testCase;
-                    await createStrategies(strategies);
 
-                    // edit one of the actions to use a strategy that does not exist
-                    tradeActions[2].strategyId = generateStrategyId(2, 1).toString();
+                    // edit one of the target orders and disable it by setting all rates to 0
+                    const index = BigNumber.from(tradeActions[0].strategyId).mask(128).sub(1).toNumber();
+                    const order = strategies[index].orders[1];
+                    order.lowestRate = '0';
+                    order.highestRate = '0';
+                    order.marginalRate = '0';
+                    await createStrategies(strategies);
 
                     // fund the user
                     await fundTrader(sourceAmount, targetAmount, byTargetAmount, sourceSymbol);
@@ -547,7 +551,7 @@ describe('Trading', () => {
                             targetSymbol,
                             byTargetAmount
                         })
-                    ).to.be.revertedWithError('StrategyDoesNotExist');
+                    ).to.be.revertedWithError('OrderDisabled');
                 });
             }
         });


### PR DESCRIPTION
The check `StrategyDoesNotExist` is based on the condition `if strategy storage slots are all 0`.

This implementation is incorrect, because the product definition allows creating such strategy, or updating an existing strategy to reach that state (for example, by withdrawing all the liquidity, and setting both rates on both orders to zero).

Implementing it in other ways would require more storage resources (thus more storage reads and writes).

On top of that, this check is conducted in every strategy-access context, i.e., trading on a strategy, updating a strategy and reading a strategy, while it is really only required in the context of trading.

Under this context, it can be done in a cheaper manner, by checking if both `A` and `B` of the target order are zero, inside each one of the trade calculation (pure) functions. Note that in contrast with the current check, this new check is per order and not for the entire strategy, and that the revert reason should subsequently change to `OrderDisabled`.