### PR TITLE
ci health workflow network fix

### DIFF
--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           node-version: '16'
 
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Health workflow requires good connectivity to make http requests - currently, some health tests are failing due to network timeouts.
Github hosted runners have flaky networking, as per this issue:
https://github.com/actions/runner-images/issues/1187
Attempting to solve the issue by using this action:
https://github.com/smorimoto/tune-github-hosted-runner-network