### PR TITLE
Reduce trading gas cost

### DIFF
--- a/contracts/carbon/CarbonController.sol
+++ b/contracts/carbon/CarbonController.sol
@@ -287,10 +287,12 @@ contract CarbonController is
             byTargetAmount: false,
             constraint: minReturn,
             txValue: msg.value,
-            pair: _pair
+            pair: _pair,
+            sourceAmount: 0,
+            targetAmount: 0
         });
-        SourceAndTargetAmounts memory amounts = _trade(tradeActions, params);
-        return amounts.targetAmount;
+        _trade(tradeActions, params);
+        return params.targetAmount;
     }
 
     /**
@@ -319,10 +321,12 @@ contract CarbonController is
             byTargetAmount: true,
             constraint: maxInput,
             txValue: msg.value,
-            pair: _pair
+            pair: _pair,
+            sourceAmount: 0,
+            targetAmount: 0
         });
-        SourceAndTargetAmounts memory amounts = _trade(tradeActions, params);
-        return amounts.sourceAmount;
+        _trade(tradeActions, params);
+        return params.sourceAmount;
     }
 
     /**

--- a/contracts/carbon/Strategies.sol
+++ b/contracts/carbon/Strategies.sol
@@ -838,7 +838,7 @@ abstract contract Strategies is Initializable {
     /**
      * @dev expand a given rate
      */
-    function _expandRate(uint256 rate) private pure returns (uint256) {
+    function _expandRate(uint256 rate) internal pure returns (uint256) {
         // safe because no `+` or `-` or `*`
         unchecked {
             return (rate % ONE) << (rate / ONE);
@@ -848,7 +848,7 @@ abstract contract Strategies is Initializable {
     /**
      * @dev validates a given rate
      */
-    function _validRate(uint256 rate) private pure returns (bool) {
+    function _validRate(uint256 rate) internal pure returns (bool) {
         // safe because no `+` or `-` or `*`
         unchecked {
             return (ONE >> (rate / ONE)) > 0;

--- a/contracts/carbon/Strategies.sol
+++ b/contracts/carbon/Strategies.sol
@@ -456,25 +456,14 @@ abstract contract Strategies is Initializable {
             }
 
             // emit update event
-            if (ordersInverted) {
-                emit StrategyUpdated({
-                    id: strategyId,
-                    token0: params.pair.tokens[1],
-                    token1: params.pair.tokens[0],
-                    order0: orders[0],
-                    order1: orders[1],
-                    reason: STRATEGY_UPDATE_REASON_TRADE
-                });
-            } else {
-                emit StrategyUpdated({
-                    id: strategyId,
-                    token0: params.pair.tokens[0],
-                    token1: params.pair.tokens[1],
-                    order0: orders[0],
-                    order1: orders[1],
-                    reason: STRATEGY_UPDATE_REASON_TRADE
-                });
-            }
+            emit StrategyUpdated({
+                id: strategyId,
+                token0: params.pair.tokens[ordersInverted ? 1 : 0],
+                token1: params.pair.tokens[ordersInverted ? 0 : 1],
+                order0: orders[0],
+                order1: orders[1],
+                reason: STRATEGY_UPDATE_REASON_TRADE
+            });
 
             params.sourceAmount += sourceAmount;
             params.targetAmount += targetAmount;

--- a/contracts/carbon/Strategies.sol
+++ b/contracts/carbon/Strategies.sol
@@ -718,7 +718,7 @@ abstract contract Strategies is Initializable {
         uint256 y, // < 2 ^ 128
         uint256 z, // < 2 ^ 128
         uint256 A, // < 2 ^ 96
-        uint256 B  // < 2 ^ 96
+        uint256 B /// < 2 ^ 96
     ) private pure returns (uint256) {
         if (A == 0) {
             if (B == 0) {
@@ -757,7 +757,7 @@ abstract contract Strategies is Initializable {
         uint256 y, // < 2 ^ 128
         uint256 z, // < 2 ^ 128
         uint256 A, // < 2 ^ 96
-        uint256 B  // < 2 ^ 96
+        uint256 B /// < 2 ^ 96
     ) private pure returns (uint256) {
         if (A == 0) {
             if (B == 0) {

--- a/contracts/carbon/Strategies.sol
+++ b/contracts/carbon/Strategies.sol
@@ -455,7 +455,7 @@ abstract contract Strategies is Initializable {
                 packedOrders[2] = newPackedOrders[2];
             }
 
-            // emit update events if necessary
+            // emit update event
             if (ordersInverted) {
                 emit StrategyUpdated({
                     id: strategyId,
@@ -509,8 +509,6 @@ abstract contract Strategies is Initializable {
             false
         );
         _withdrawFunds(params.tokens.target, payable(params.trader), params.targetAmount);
-
-        // update fee counters
 
         // tokens traded successfully, emit event
         emit TokensTraded({

--- a/contracts/carbon/Strategies.sol
+++ b/contracts/carbon/Strategies.sol
@@ -451,7 +451,7 @@ abstract contract Strategies is Initializable {
             }
 
             // the other z value has possibly changed only if the first one hasn't
-            else if (packedOrdersMemory[2] != newPackedOrders[2]) {
+            if (packedOrdersMemory[2] != newPackedOrders[2]) {
                 packedOrders[2] = newPackedOrders[2];
             }
 

--- a/contracts/carbon/Strategies.sol
+++ b/contracts/carbon/Strategies.sol
@@ -725,11 +725,11 @@ abstract contract Strategies is Initializable {
      *
      */
     function _calculateTradeTargetAmount(
-        uint256 x,
-        uint256 y,
-        uint256 z,
-        uint256 A,
-        uint256 B
+        uint256 x, // < 2 ^ 128
+        uint256 y, // < 2 ^ 128
+        uint256 z, // < 2 ^ 128
+        uint256 A, // < 2 ^ 96
+        uint256 B  // < 2 ^ 96
     ) private pure returns (uint256) {
         if (A == 0) {
             if (B == 0) {
@@ -764,11 +764,11 @@ abstract contract Strategies is Initializable {
      *
      */
     function _calculateTradeSourceAmount(
-        uint256 x,
-        uint256 y,
-        uint256 z,
-        uint256 A,
-        uint256 B
+        uint256 x, // < 2 ^ 128
+        uint256 y, // < 2 ^ 128
+        uint256 z, // < 2 ^ 128
+        uint256 A, // < 2 ^ 96
+        uint256 B  // < 2 ^ 96
     ) private pure returns (uint256) {
         if (A == 0) {
             if (B == 0) {

--- a/contracts/helpers/TestStrategies.sol
+++ b/contracts/helpers/TestStrategies.sol
@@ -13,4 +13,12 @@ contract TestStrategies is Strategies {
         (uint128 sourceAmount, ) = _singleTradeActionSourceAndTargetAmounts(order, amount, true);
         return sourceAmount;
     }
+
+    function isValidRate(uint256 rate) external pure returns (bool) {
+        return _validRate(rate);
+    }
+
+    function expandedRate(uint256 rate) external pure returns (uint256) {
+        return _expandRate(rate);
+    }
 }

--- a/contracts/helpers/TestStrategies.sol
+++ b/contracts/helpers/TestStrategies.sol
@@ -5,10 +5,12 @@ import { Strategies, Order } from "../carbon/Strategies.sol";
 
 contract TestStrategies is Strategies {
     function tradeBySourceAmount(Order memory order, uint128 amount) external pure returns (uint128) {
-        return _singleTradeActionSourceAndTargetAmounts(order, amount, false).targetAmount;
+        (, uint128 targetAmount) = _singleTradeActionSourceAndTargetAmounts(order, amount, false);
+        return targetAmount;
     }
 
     function tradeByTargetAmount(Order memory order, uint128 amount) external pure returns (uint128) {
-        return _singleTradeActionSourceAndTargetAmounts(order, amount, true).sourceAmount;
+        (uint128 sourceAmount, ) = _singleTradeActionSourceAndTargetAmounts(order, amount, true);
+        return sourceAmount;
     }
 }

--- a/contracts/utility/MathEx.sol
+++ b/contracts/utility/MathEx.sol
@@ -58,8 +58,8 @@ library MathEx {
     }
 
     /**
-    * @dev returns the smallest integer `z` such that `x * y / z <= 2 ^ 256 - 1`
-    */
+     * @dev returns the smallest integer `z` such that `x * y / z <= 2 ^ 256 - 1`
+     */
     function minFactor(uint256 x, uint256 y) internal pure returns (uint256) {
         (uint256 hi, uint256 lo) = _mul512(x, y);
         unchecked {

--- a/test/utility/MathEx.ts
+++ b/test/utility/MathEx.ts
@@ -31,7 +31,14 @@ describe('MathEx', () => {
             });
         }
 
-        const tuples = [[x, y], [x, z], [y, z], [x, y.add(z)], [x.add(z), y], [x.add(z), y.add(z)]];
+        const tuples = [
+            [x, y],
+            [x, z],
+            [y, z],
+            [x, y.add(z)],
+            [x.add(z), y],
+            [x.add(z), y.add(z)]
+        ];
         const values = tuples.filter((tuple) => tuple.every((value) => value.lte(MAX_UINT256)));
         for (const [x, y] of values) {
             it(`minFactor(${x}, ${y})`, async () => {


### PR DESCRIPTION
Notes:
1. It is not possible to quantify the impact of each change independently, because these changes are tightly-coupled in terms of gas.
2. A few of these changes are actually in favor of reducing stack size, in order to allow for the other (gas-related) changes to be compilable.