### PR TITLE
Reduce the gas cost of trading on constant-rate orders

### DIFF
--- a/contracts/carbon/Strategies.sol
+++ b/contracts/carbon/Strategies.sol
@@ -435,7 +435,7 @@ abstract contract Strategies is Initializable {
             }
 
             sourceOrder.y += sourceAmount;
-            if (sourceOrder.z < sourceOrder.y) {
+            if (sourceOrder.z < sourceOrder.y && sourceOrder.A != 0) {
                 sourceOrder.z = sourceOrder.y;
             }
 
@@ -870,7 +870,7 @@ abstract contract Strategies is Initializable {
      */
     function _validateOrders(Order[2] calldata orders) internal pure {
         for (uint256 i = 0; i < 2; i = uncheckedInc(i)) {
-            if (orders[i].z < orders[i].y) {
+            if (orders[i].z < orders[i].y && orders[i].A != 0) {
                 revert InsufficientCapacity();
             }
             if (!_validRate(orders[i].A)) {

--- a/test/forge/Strategies.t.sol
+++ b/test/forge/Strategies.t.sol
@@ -408,18 +408,20 @@ contract StrategiesTest is TestFixture {
         carbonController.createStrategy(token0, token1, [order, order]);
     }
 
-    function testSStrategyCreationRevertsWhenCapacityIsSmallerThanLiquidity(bool order0Insufficient) public {
+    function testStrategyCreationRevertsWhenCapacityIsSmallerThanLiquidity(bool order0Insufficient, bool order0Constant) public {
         vm.startPrank(user1);
 
         Order memory order0 = generateTestOrder();
         Order memory order1 = generateTestOrder();
-        if (order0Insufficient) {
-            order0.z = order0.y - 1;
+        Order memory orderPtr = order0Insufficient ? order0 : order1;
+        orderPtr.z = orderPtr.y - 1;
+
+        if (order0Constant) {
+            orderPtr.A = 0;
         } else {
-            order1.z = order1.y - 1;
+            vm.expectRevert(Strategies.InsufficientCapacity.selector);
         }
 
-        vm.expectRevert(Strategies.InsufficientCapacity.selector);
         carbonController.createStrategy(token0, token1, [order0, order1]);
 
         vm.stopPrank();
@@ -904,7 +906,7 @@ contract StrategiesTest is TestFixture {
         carbonController.updateStrategy(strategyId, [order, order], [newOrder, newOrder]);
     }
 
-    function testStrategyUpdateRevertsWhenCapacityIsSmallerThanLiquidity(bool order0Insufficient) public {
+    function testStrategyUpdateRevertsWhenCapacityIsSmallerThanLiquidity(bool order0Insufficient, bool order0Constant) public {
         vm.startPrank(user1);
 
         Order memory order = generateTestOrder();
@@ -912,13 +914,15 @@ contract StrategiesTest is TestFixture {
 
         Order memory order0 = generateTestOrder();
         Order memory order1 = generateTestOrder();
-        if (order0Insufficient) {
-            order0.z = order0.y - 1;
+        Order memory orderPtr = order0Insufficient ? order0 : order1;
+        orderPtr.z = orderPtr.y - 1;
+
+        if (order0Constant) {
+            orderPtr.A = 0;
         } else {
-            order1.z = order1.y - 1;
+            vm.expectRevert(Strategies.InsufficientCapacity.selector);
         }
 
-        vm.expectRevert(Strategies.InsufficientCapacity.selector);
         carbonController.updateStrategy(strategyId, [order, order], [order0, order1]);
 
         vm.stopPrank();


### PR DESCRIPTION
Reduce the gas cost of trading on constant-rate orders, by updating `z` only when `A != 0`.

SDK:
1. When creating/updating a constant-rate order (`A = 0`), can pass `z = 0` in order to reduce user's gas cost
2. When updating a constant-rate order to dynamic-rate, should not rely on current `z` in order to determine new `z`

This PR is an alternative for https://github.com/bancorprotocol/carbon-sdk/pull/25.