### PR TITLE
Increase the maximum permitted value of `timeElapsed / halfLife` from ~23 to 128

### DIFF
--- a/contracts/utility/ExpDecayMath.sol
+++ b/contracts/utility/ExpDecayMath.sol
@@ -12,7 +12,7 @@ library ExpDecayMath {
      * @dev returns the amount required for a token after a given time period since trading has been enabled
      *
      * the returned value is calculated as `amount / 2 ^ (timeElapsed / halfLife)`
-     * note that the input value to this function is limited by `timeElapsed / halfLife <= 128`
+     * note that the input value to this function is limited by `timeElapsed / halfLife < 129`
      */
     function calcExpDecay(uint256 amount, uint32 timeElapsed, uint32 halfLife) internal pure returns (uint256) {
         uint256 integerPart = timeElapsed / halfLife;

--- a/contracts/utility/ExpDecayMath.sol
+++ b/contracts/utility/ExpDecayMath.sol
@@ -12,12 +12,13 @@ library ExpDecayMath {
      * @dev returns the amount required for a token after a given time period since trading has been enabled
      *
      * the returned value is calculated as `amount / 2 ^ (timeElapsed / halfLife)`
-     * note that because the exponentiation function is limited to an input of up to (and excluding)
-     * 16 / ln 2, the input value to this function is limited by `timeElapsed / halfLife < 16 / ln 2`
+     * note that the input value to this function is limited by `timeElapsed / halfLife <= 128`
      */
     function calcExpDecay(uint256 amount, uint32 timeElapsed, uint32 halfLife) internal pure returns (uint256) {
-        Fraction memory input = Fraction({ n: timeElapsed, d: halfLife });
+        uint256 integerPart = timeElapsed / halfLife;
+        uint256 fractionPart = timeElapsed % halfLife;
+        Fraction memory input = Fraction({ n: fractionPart , d: halfLife });
         Fraction memory output = MathEx.exp2(input);
-        return MathEx.mulDivF(amount, output.d, output.n);
+        return MathEx.mulDivF(amount, output.d, output.n * 2 ** integerPart);
     }
 }

--- a/test/math/ExpDecayMath.ts
+++ b/test/math/ExpDecayMath.ts
@@ -12,7 +12,7 @@ describe('ExpDecayMath', () => {
     let expDecayMath: TestExpDecayMath;
     const ONE = new Decimal(1);
     const TWO = new Decimal(2);
-    const MAX = new Decimal(128);
+    const MAX = new Decimal(129);
 
     before(async () => {
         expDecayMath = await Contracts.TestExpDecayMath.deploy();
@@ -21,7 +21,7 @@ describe('ExpDecayMath', () => {
     const calcExpDecay = (ethAmount: BigNumberish, timeElapsed: number, halfLife: number) => {
         it(`calcExpDecay(${ethAmount}, ${timeElapsed}, ${halfLife})`, async () => {
             const f = new Decimal(timeElapsed).div(halfLife);
-            if (f.lte(MAX)) {
+            if (f.lt(MAX)) {
                 const f = new Decimal(timeElapsed).div(halfLife);
                 // actual amount calculated in solidity
                 const actual = await expDecayMath.calcExpDecay(ethAmount, timeElapsed, halfLife);
@@ -68,6 +68,11 @@ describe('ExpDecayMath', () => {
                     calcExpDecay(ethAmount, timeElapsed, halfLife);
                 }
             }
+        }
+
+        for (const halfLife of [seconds(1), minutes(2), hours(3), days(2), years(1)]) {
+            calcExpDecay(1_000_000, MAX.toNumber() * halfLife - 1, halfLife); // should pass
+            calcExpDecay(1_000_000, MAX.toNumber() * halfLife - 0, halfLife); // should fail
         }
     });
 

--- a/test/math/ExpDecayMath.ts
+++ b/test/math/ExpDecayMath.ts
@@ -71,7 +71,7 @@ describe('ExpDecayMath', () => {
         }
     });
 
-    describe('stress tests', () => {
+    describe('@stress tests', () => {
         for (const ethAmount of [
             40_000_000,
             400_000_000,

--- a/test/math/ExpDecayMath.ts
+++ b/test/math/ExpDecayMath.ts
@@ -1,5 +1,4 @@
 import Contracts, { TestExpDecayMath } from '../../components/Contracts';
-import { EXP2_INPUT_TOO_HIGH } from '../../utils/Constants';
 import { toWei } from '../../utils/Types';
 import { duration } from '../helpers/Time';
 import { Relation } from '../matchers';
@@ -13,6 +12,7 @@ describe('ExpDecayMath', () => {
     let expDecayMath: TestExpDecayMath;
     const ONE = new Decimal(1);
     const TWO = new Decimal(2);
+    const MAX = new Decimal(128);
 
     before(async () => {
         expDecayMath = await Contracts.TestExpDecayMath.deploy();
@@ -21,7 +21,7 @@ describe('ExpDecayMath', () => {
     const calcExpDecay = (ethAmount: BigNumberish, timeElapsed: number, halfLife: number) => {
         it(`calcExpDecay(${ethAmount}, ${timeElapsed}, ${halfLife})`, async () => {
             const f = new Decimal(timeElapsed).div(halfLife);
-            if (f.lt(EXP2_INPUT_TOO_HIGH)) {
+            if (f.lte(MAX)) {
                 const f = new Decimal(timeElapsed).div(halfLife);
                 // actual amount calculated in solidity
                 const actual = await expDecayMath.calcExpDecay(ethAmount, timeElapsed, halfLife);
@@ -33,7 +33,7 @@ describe('ExpDecayMath', () => {
                 });
             } else {
                 await expect(expDecayMath.calcExpDecay(ethAmount, timeElapsed, halfLife)).to.revertedWithError(
-                    'Overflow'
+                    'panic code 0x11'
                 );
             }
         });
@@ -71,7 +71,7 @@ describe('ExpDecayMath', () => {
         }
     });
 
-    describe('@stress tests', () => {
+    describe('stress tests', () => {
         for (const ethAmount of [
             40_000_000,
             400_000_000,

--- a/test/utility/MathEx.ts
+++ b/test/utility/MathEx.ts
@@ -105,6 +105,14 @@ describe('MathEx', () => {
                 testExp2({ n: n.floor().toNumber(), d }, new Decimal('0.000000000000000000000000000000000002'));
             }
         }
+
+        for (let d = 1; d < 1000; d++) {
+            testExp2({ n: 1, d }, new Decimal('0.00000000000000000000000000000000000002'));
+        }
+
+        for (let n = 1; n < 1000; n++) {
+            testExp2({ n, d: 1000 }, new Decimal('0.0000000000000000000000000000000000001'));
+        }
     });
 
     describe('@stress tests', () => {


### PR DESCRIPTION
The calculation of `2 ^ x` for a non-integer value of `x` is limited by `x < 16 * ln(2)`, which is approximately 23.08.

The solution to this problem relies on the identity:
```
A ^ B.C = A ^ (B + 0.C) = A ^ B * A ^ 0.C
```
For example:
```
2 ^ 3.4 = 2 ^ (3 + 0.4) = 2 ^ 3 * 2 ^ 0.4
```
Calculating `2 ^ 3` is easy, and calculating `2 ^ 0.4` is also easy, because `0.4` is way below the limit (23.08).