### PR TITLE
carbon vortex 2.0 target token min sale amount handling

### DIFF
--- a/contracts/vortex/CarbonVortex.sol
+++ b/contracts/vortex/CarbonVortex.sol
@@ -652,6 +652,15 @@ contract CarbonVortex is ICarbonVortex, Upgradeable, ReentrancyGuardUpgradeable,
             _resetTrading(token, 0);
         }
 
+        // if available target token trading amount is below the min target token sale amount, reset the target token auction
+        if (
+            Token.unwrap(_finalTargetToken) != address(0) &&
+            _amountAvailableForTrading(_targetToken) <
+            _minTokenSaleAmounts[_targetToken] / _minTokenSaleAmountMultiplier
+        ) {
+            _resetTradingTarget(0);
+        }
+
         // if the target token is native, refund any excess native token to caller
         if (_targetToken == NATIVE_TOKEN && msg.value > sourceAmount) {
             payable(msg.sender).sendValue(msg.value - sourceAmount);

--- a/deployments/setup-testnet.ts
+++ b/deployments/setup-testnet.ts
@@ -63,6 +63,13 @@ const fundAccount = async (account: string, fundingRequests: FundingRequest[]) =
         }
 
         const tokenContract = await Contracts.ERC20.attach(fundingRequest.token);
+
+        // check if whale has enough balance
+        const whaleBalance = await tokenContract.balanceOf(whale.address);
+        if (whaleBalance.lt(fundingRequest.amount)) {
+            Logger.error(`Whale ${whale.address} has insufficient balance for ${fundingRequest.tokenName}`);
+            continue;
+        }
         await tokenContract.connect(whale).transfer(account, fundingRequest.amount);
     }
 };


### PR DESCRIPTION
* Add handling for a below the min sale amount case for the target token during TKN->target token trades
* Add tests