### PR TITLE
deployment scripts fix

### DIFF
--- a/deployments/run-fork.sh
+++ b/deployments/run-fork.sh
@@ -59,8 +59,7 @@ fi
 
 # if deploy/scripts/${network_name} doesn't exist, create it and copy the network scripts
 if [ ! -d "./deploy/scripts/${network_name}" ]; then
-    mkdir -p ./deploy/scripts/${network_name}
-    cp -r ./deploy/scripts/network/ ./deploy/scripts/${network_name}/
+    rsync -a --delete ./deploy/scripts/network/ ./deploy/scripts/${network_name}/
 fi
 
 # Create a new dir for the deploy script files and copy them there

--- a/deployments/run-network.sh
+++ b/deployments/run-network.sh
@@ -23,9 +23,8 @@ if [ -z "$network_id" ] || [ "$network_id" == "null" ]; then
     network_id=${TENDERLY_NETWORK_ID:-"1"}
 fi
 
-# Create a new dir for the deploy script files and copy them there
-mkdir -p ./deploy/scripts/${network_name}
-cp -r ./deploy/scripts/network/ ./deploy/scripts/${network_name}/
+# Create a new dir for the deploy script files and copy them there)
+rsync -a --delete ./deploy/scripts/network/ ./deploy/scripts/${network_name}/
 
 # Create a new dir for the deployment files
 mkdir -p ./deployments/${network_name}

--- a/deployments/run-testnet.sh
+++ b/deployments/run-testnet.sh
@@ -79,8 +79,7 @@ fi
 
 # if deploy/scripts/${network_name} doesn't exist, create it and copy the network scripts
 if [ ! -d "./deploy/scripts/${network_name}" ]; then
-    mkdir -p ./deploy/scripts/${network_name}
-    cp -r ./deploy/scripts/network/ ./deploy/scripts/${network_name}/
+    rsync -a --delete ./deploy/scripts/network/ ./deploy/scripts/${network_name}/
 fi
 
 # Create a new dir for the deploy script files and copy them there


### PR DESCRIPTION
* Replace `cp` with `rsync` in the deployment scripts to fix different OS behaviors and fully synchronize the deployment script directories