### PR TITLE
Gradient strategies test improvement

### DIFF
--- a/contracts/helpers/TestTrade.sol
+++ b/contracts/helpers/TestTrade.sol
@@ -33,6 +33,10 @@ contract TestTrade {
         return Trade.calcCurrentRate(gradientType, initialRate, multiFactor, timeElapsed);
     }
 
+    function sub(uint256 one, uint256 mt) external pure returns (uint256) {
+        return Trade.sub(one, mt);
+    }
+
     function exp(uint256 x) external pure returns (uint256) {
         return Trade.exp(x);
     }

--- a/contracts/helpers/TestTrade.sol
+++ b/contracts/helpers/TestTrade.sol
@@ -32,4 +32,8 @@ contract TestTrade {
     ) external pure returns (uint256, uint256) {
         return Trade.calcCurrentRate(gradientType, initialRate, multiFactor, timeElapsed);
     }
+
+    function exp(uint256 x) external pure returns (uint256) {
+        return Trade.exp(x);
+    }
 }

--- a/contracts/utility/Trade.sol
+++ b/contracts/utility/Trade.sol
@@ -56,7 +56,12 @@ library Trade {
     }
 
     /**
-     * @dev Calculate the current rate for each one of the following gradients:
+     * @dev Given the following parameters:
+     * r - the gradient's initial exchange rate
+     * m - the gradient's multiplication factor
+     * t - the time elapsed since strategy creation
+     *
+     * Calculate the current exchange rate for each one of the following gradients:
      * +----------------+-----------+-----------------+----------------------------------------------+
      * | type           | direction | formula         | restriction                                  |
      * +----------------+-----------+-----------------+----------------------------------------------+
@@ -70,9 +75,9 @@ library Trade {
      */
     function calcCurrentRate(
         GradientType gradientType,
-        uint64 initialRate,
-        uint32 multiFactor,
-        uint32 timeElapsed
+        uint64 initialRate, // the 48-bit-mantissa-6-bit-exponent encoding of the initial exchange rate square root
+        uint32 multiFactor, // the 24-bit-mantissa-5-bit-exponent encoding of the multiplication factor times 2 ^ 24
+        uint32 timeElapsed /// the time elapsed since strategy creation
     ) internal pure returns (uint256, uint256) {
         unchecked {
             if ((R_ONE >> (initialRate / R_ONE)) == 0) {

--- a/contracts/utility/Trade.sol
+++ b/contracts/utility/Trade.sol
@@ -19,6 +19,7 @@ library Trade {
     uint256 private constant MM = M_ONE * M_ONE; // = 2 ^ 48
 
     uint256 private constant RR_MUL_MM = RR * MM; // = 2 ^ 144
+    uint256 private constant RR_DIV_MM = RR / MM; // = 2 ^ 48
 
     uint256 private constant EXP_ONE_MUL_RR = EXP_ONE * RR; // = 2 ^ 223
     uint256 private constant EXP_ONE_DIV_RR = EXP_ONE / RR; // = 2 ^ 31
@@ -113,15 +114,15 @@ library Trade {
 
             if (gradientType == GradientType.LINEAR_INV_INCREASE) {
                 // initial_rate / (1 - multi_factor * time_elapsed)
-                uint256 temp1 = rr * MM; ////////////////// < 2 ^ 240
-                uint256 temp2 = sub(RR_MUL_MM, mt * RR); // < 2 ^ 176 (inner expression)
+                uint256 temp1 = rr;
+                uint256 temp2 = sub(RR, mt * RR_DIV_MM); // < 2 ^ 128 (inner expression)
                 return (temp1, temp2);
             }
 
             if (gradientType == GradientType.LINEAR_INV_DECREASE) {
                 // initial_rate / (1 + multi_factor * time_elapsed)
-                uint256 temp1 = rr * MM; ////////////// < 2 ^ 240
-                uint256 temp2 = RR_MUL_MM + mt * RR; // < 2 ^ 177
+                uint256 temp1 = rr;
+                uint256 temp2 = RR + mt * RR_DIV_MM; // < 2 ^ 129
                 return (temp1, temp2);
             }
 

--- a/contracts/utility/Trade.sol
+++ b/contracts/utility/Trade.sol
@@ -146,7 +146,7 @@ library Trade {
         }
     }
 
-    function sub(uint256 one, uint256 mt) private pure returns (uint256) {
+    function sub(uint256 one, uint256 mt) internal pure returns (uint256) {
         unchecked {
             if (one <= mt) {
                 revert InvalidRate();
@@ -165,7 +165,7 @@ library Trade {
      * - The exponentiation of the input is calculated by multiplying the intermediate results above
      * - For example: e^5.521692859 = e^(4 + 1 + 0.5 + 0.021692859) = e^4 * e^1 * e^0.5 * e^0.021692859
      */
-    function exp(uint256 x) private pure returns (uint256) {
+    function exp(uint256 x) internal pure returns (uint256) {
         // prettier-ignore
         unchecked {
             if (x >= MAX_VAL) {

--- a/contracts/utility/Trade.sol
+++ b/contracts/utility/Trade.sol
@@ -5,6 +5,7 @@ import { MathEx } from "./MathEx.sol";
 
 library Trade {
     error ExpOverflow();
+    error InvalidRate();
     error InitialRateTooHigh();
     error MultiFactorTooHigh();
 
@@ -26,6 +27,8 @@ library Trade {
     enum GradientType {
         LINEAR_INCREASE,
         LINEAR_DECREASE,
+        LINEAR_INV_INCREASE,
+        LINEAR_INV_DECREASE,
         EXPONENTIAL_INCREASE,
         EXPONENTIAL_DECREASE
     }
@@ -67,30 +70,47 @@ library Trade {
                 revert MultiFactorTooHigh();
             }
 
-            uint256 r = uint256(initialRate % R_ONE) << (initialRate / R_ONE); // floor(sqrt(initial_rate) * 2 ^ 48)    < 2 ^ 96
-            uint256 m = uint256(multiFactor % M_ONE) << (multiFactor / M_ONE); // floor(multi_factor * 2 ^ 24 * 2 ^ 24) < 2 ^ 48
+            uint256 r = uint256(initialRate % R_ONE) << (initialRate / R_ONE); // = floor(sqrt(initial_rate) * 2 ^ 48)    < 2 ^ 96
+            uint256 m = uint256(multiFactor % M_ONE) << (multiFactor / M_ONE); // = floor(multi_factor * 2 ^ 24 * 2 ^ 24) < 2 ^ 48
             uint256 t = uint256(timeElapsed);
 
+            uint256 rr = r * r; // < 2 ^ 192
+            uint256 mt = m * t; // < 2 ^ 80
+
             if (gradientType == GradientType.LINEAR_INCREASE) {
-                // initial_rate * (multi_factor * time_elapsed + 1)
-                uint256 temp1 = r * r; /////// < 2 ^ 192
-                uint256 temp2 = m * t + MM; // < 2 ^ 81
+                // initial_rate * (1 + multi_factor * time_elapsed)
+                uint256 temp1 = rr; /////// < 2 ^ 192
+                uint256 temp2 = MM + mt; // < 2 ^ 81
                 uint256 temp3 = MathEx.minFactor(temp1, temp2);
                 uint256 temp4 = RR_MUL_MM;
                 return (MathEx.mulDivF(temp1, temp2, temp3), temp4 / temp3); // not ideal
             }
 
             if (gradientType == GradientType.LINEAR_DECREASE) {
-                // initial_rate / (multi_factor * time_elapsed + 1)
-                uint256 temp1 = r * r * MM; ////////////// < 2 ^ 240
-                uint256 temp2 = m * t * RR + RR_MUL_MM; // < 2 ^ 177
+                // initial_rate * (1 - multi_factor * time_elapsed)
+                uint256 temp1 = rr * sub(MM, mt); // < 2 ^ 240
+                uint256 temp2 = RR_MUL_MM;
+                return (temp1, temp2);
+            }
+
+            if (gradientType == GradientType.LINEAR_INV_INCREASE) {
+                // initial_rate / (1 - multi_factor * time_elapsed)
+                uint256 temp1 = rr * MM; ////////////////// < 2 ^ 240
+                uint256 temp2 = sub(RR_MUL_MM, mt * RR); // < 2 ^ 176 (inner expression)
+                return (temp1, temp2);
+            }
+
+            if (gradientType == GradientType.LINEAR_INV_DECREASE) {
+                // initial_rate / (1 + multi_factor * time_elapsed)
+                uint256 temp1 = rr * MM; ////////////// < 2 ^ 240
+                uint256 temp2 = RR_MUL_MM + mt * RR; // < 2 ^ 177
                 return (temp1, temp2);
             }
 
             if (gradientType == GradientType.EXPONENTIAL_INCREASE) {
                 // initial_rate * e ^ (multi_factor * time_elapsed)
-                uint256 temp1 = r * r; //////////////////////// < 2 ^ 192
-                uint256 temp2 = exp(m * t * EXP_ONE_DIV_MM); // < 2 ^ 159 (inner expression)
+                uint256 temp1 = rr; //////////////////////// < 2 ^ 192
+                uint256 temp2 = exp(mt * EXP_ONE_DIV_MM); // < 2 ^ 159 (inner expression)
                 uint256 temp3 = MathEx.minFactor(temp1, temp2);
                 uint256 temp4 = EXP_ONE_MUL_RR;
                 return (MathEx.mulDivF(temp1, temp2, temp3), temp4 / temp3); // not ideal
@@ -98,12 +118,21 @@ library Trade {
 
             if (gradientType == GradientType.EXPONENTIAL_DECREASE) {
                 // initial_rate / e ^ (multi_factor * time_elapsed)
-                uint256 temp1 = r * r * EXP_ONE_DIV_RR; /////// < 2 ^ 223
-                uint256 temp2 = exp(m * t * EXP_ONE_DIV_MM); // < 2 ^ 159 (inner expression)
+                uint256 temp1 = rr * EXP_ONE_DIV_RR; /////// < 2 ^ 223
+                uint256 temp2 = exp(mt * EXP_ONE_DIV_MM); // < 2 ^ 159 (inner expression)
                 return (temp1, temp2);
             }
 
             return (0, 0);
+        }
+    }
+
+    function sub(uint256 one, uint256 mt) private pure returns (uint256) {
+        unchecked {
+            if (one <= mt) {
+                revert InvalidRate();
+            }
+            return one - mt;
         }
     }
 

--- a/contracts/utility/Trade.sol
+++ b/contracts/utility/Trade.sol
@@ -52,7 +52,7 @@ library Trade {
         uint32 timeElapsed,
         uint256 targetAmount
     ) internal pure returns (uint256) {
-        (uint256 d, uint256 n) = calcCurrentRate(gradientType, initialRate, multiFactor, timeElapsed);
+        (uint256 n, uint256 d) = calcCurrentRate(gradientType, initialRate, multiFactor, timeElapsed);
         return MathEx.mulDivC(targetAmount, d, n);
     }
 

--- a/contracts/utility/Trade.sol
+++ b/contracts/utility/Trade.sol
@@ -3,6 +3,22 @@ pragma solidity 0.8.19;
 
 import { MathEx } from "./MathEx.sol";
 
+/**
+ * @dev:
+ *
+ * This library implements the current-rate calculation for each one of the following gradients:
+ * +----------------+-----------+-----------------+----------------------------------------------+
+ * | type           | direction | formula         | restriction                                  |
+ * +----------------+-----------+-----------------+----------------------------------------------+
+ * | linear         | increase  | r * (1 + m * t) |                                              |
+ * | linear         | decrease  | r * (1 - m * t) | m * t < 1 (ensure a finite-positive rate)    |
+ * | linear-inverse | increase  | r / (1 - m * t) | m * t < 1 (ensure a finite-positive rate)    |
+ * | linear-inverse | decrease  | r / (1 + m * t) |                                              |
+ * | exponential    | increase  | r * e ^ (m * t) | m * t < 16 (due to computational limitation) |
+ * | exponential    | decrease  | r / e ^ (m * t) | m * t < 16 (due to computational limitation) |
+ * +----------------+-----------+-----------------+----------------------------------------------+
+ */
+
 library Trade {
     error ExpOverflow();
     error InvalidRate();

--- a/contracts/utility/Trade.sol
+++ b/contracts/utility/Trade.sol
@@ -3,22 +3,6 @@ pragma solidity 0.8.19;
 
 import { MathEx } from "./MathEx.sol";
 
-/**
- * @dev:
- *
- * This library implements the current-rate calculation for each one of the following gradients:
- * +----------------+-----------+-----------------+----------------------------------------------+
- * | type           | direction | formula         | restriction                                  |
- * +----------------+-----------+-----------------+----------------------------------------------+
- * | linear         | increase  | r * (1 + m * t) |                                              |
- * | linear         | decrease  | r * (1 - m * t) | m * t < 1 (ensure a finite-positive rate)    |
- * | linear-inverse | increase  | r / (1 - m * t) | m * t < 1 (ensure a finite-positive rate)    |
- * | linear-inverse | decrease  | r / (1 + m * t) |                                              |
- * | exponential    | increase  | r * e ^ (m * t) | m * t < 16 (due to computational limitation) |
- * | exponential    | decrease  | r / e ^ (m * t) | m * t < 16 (due to computational limitation) |
- * +----------------+-----------+-----------------+----------------------------------------------+
- */
-
 library Trade {
     error ExpOverflow();
     error InvalidRate();
@@ -71,6 +55,19 @@ library Trade {
         return MathEx.mulDivC(targetAmount, d, n);
     }
 
+    /**
+     * @dev Calculate the current rate for each one of the following gradients:
+     * +----------------+-----------+-----------------+----------------------------------------------+
+     * | type           | direction | formula         | restriction                                  |
+     * +----------------+-----------+-----------------+----------------------------------------------+
+     * | linear         | increase  | r * (1 + m * t) |                                              |
+     * | linear         | decrease  | r * (1 - m * t) | m * t < 1 (ensure a finite-positive rate)    |
+     * | linear-inverse | increase  | r / (1 - m * t) | m * t < 1 (ensure a finite-positive rate)    |
+     * | linear-inverse | decrease  | r / (1 + m * t) |                                              |
+     * | exponential    | increase  | r * e ^ (m * t) | m * t < 16 (due to computational limitation) |
+     * | exponential    | decrease  | r / e ^ (m * t) | m * t < 16 (due to computational limitation) |
+     * +----------------+-----------+-----------------+----------------------------------------------+
+     */
     function calcCurrentRate(
         GradientType gradientType,
         uint64 initialRate,

--- a/test/carbon/accuracy/gradient_strategies.ts
+++ b/test/carbon/accuracy/gradient_strategies.ts
@@ -184,6 +184,6 @@ describe('Gradient strategies accuracy stress test', () => {
 
     for (let b = -14; b <= -1; b++) {
         const multiFactor = new Decimal(10).pow(b);
-        testConfiguration("multiFactor", multiFactor, multiFactorEncoded, multiFactorDecoded, "0.000000000000004", "0.0000002");
+        testConfiguration("multiFactor", multiFactor, multiFactorEncoded, multiFactorDecoded, "0.000000000000004", "0.00000007");
     }
 });

--- a/test/carbon/accuracy/gradient_strategies.ts
+++ b/test/carbon/accuracy/gradient_strategies.ts
@@ -70,16 +70,6 @@ function expectedCurrentRate(
     throw new Error(`Invalid gradientType ${gradientType}`);
 }
 
-async function actualCurrentRate(
-    gradientType: number,
-    initialRate: BigNumber,
-    multiFactor: BigNumber,
-    timeElapsed: BigNumber
-) {
-    const currentRate = await contract.calcCurrentRate(gradientType, initialRate, multiFactor, timeElapsed);
-    return BnToDec(currentRate[0]).div(BnToDec(currentRate[1]));
-}
-
 function testCurrentRate(
     gradientType: number,
     initialRate: Decimal,
@@ -93,9 +83,10 @@ function testCurrentRate(
         const rDecoded = initialRateDecoded(rEncoded);
         const mDecoded = multiFactorDecoded(mEncoded);
         const expected = expectedCurrentRate(gradientType, rDecoded, mDecoded, timeElapsed);
-        const funcCall = actualCurrentRate(gradientType, rEncoded, mEncoded, DecToBn(timeElapsed));
+        const funcCall = contract.calcCurrentRate(gradientType, rEncoded, mEncoded, DecToBn(timeElapsed));
         if (expected.isFinite() && expected.isPositive()) {
-            const actual = await funcCall;
+            const retVal = await funcCall;
+            const actual = BnToDec(retVal[0]).div(BnToDec(retVal[1]))
             if (!actual.eq(expected)) {
                 const error = actual.div(expected).sub(1).abs();
                 expect(error.lte(maxError)).to.be.equal(

--- a/test/carbon/accuracy/gradient_strategies.ts
+++ b/test/carbon/accuracy/gradient_strategies.ts
@@ -141,7 +141,7 @@ function testConfiguration(
     });
 }
 
-describe.only('Gradient strategies accuracy stress test', () => {
+describe('Gradient strategies accuracy stress test', () => {
     before(async () => {
         contract = await Contracts.TestTrade.deploy();
     });
@@ -152,12 +152,12 @@ describe.only('Gradient strategies accuracy stress test', () => {
                 const initialRate = new Decimal(a).mul(1234.5678);
                 const multiFactor = new Decimal(b).mul(0.00001234);
                 const timeElapsed = new Decimal(c).mul(3600);
-                testCurrentRate(0, initialRate, multiFactor, timeElapsed, "0");
-                testCurrentRate(1, initialRate, multiFactor, timeElapsed, "0");
-                testCurrentRate(2, initialRate, multiFactor, timeElapsed, "0");
-                testCurrentRate(3, initialRate, multiFactor, timeElapsed, "0");
-                testCurrentRate(4, initialRate, multiFactor, timeElapsed, "0.00000000000000000000000000000000000002");
-                testCurrentRate(5, initialRate, multiFactor, timeElapsed, "0.00000000000000000000000000000000000002");
+                testCurrentRate(0, initialRate, multiFactor, timeElapsed, '0');
+                testCurrentRate(1, initialRate, multiFactor, timeElapsed, '0');
+                testCurrentRate(2, initialRate, multiFactor, timeElapsed, '0');
+                testCurrentRate(3, initialRate, multiFactor, timeElapsed, '0');
+                testCurrentRate(4, initialRate, multiFactor, timeElapsed, '0.00000000000000000000000000000000000002');
+                testCurrentRate(5, initialRate, multiFactor, timeElapsed, '0.00000000000000000000000000000000000002');
             }
         }
     }
@@ -171,33 +171,33 @@ describe.only('Gradient strategies accuracy stress test', () => {
                     TWO.pow(4).div(multiFactor).sub(1).ceil(),
                     TWO.pow(25).sub(1)
                 ).mul(c).div(10).ceil();
-                testCurrentRate(0, initialRate, multiFactor, timeElapsed, "0");
-                testCurrentRate(1, initialRate, multiFactor, timeElapsed, "0");
-                testCurrentRate(2, initialRate, multiFactor, timeElapsed, "0");
-                testCurrentRate(3, initialRate, multiFactor, timeElapsed, "0");
-                testCurrentRate(4, initialRate, multiFactor, timeElapsed, "0.000000000000000000000000000000000002");
-                testCurrentRate(5, initialRate, multiFactor, timeElapsed, "0.000000000000000000000000000000000002");
+                testCurrentRate(0, initialRate, multiFactor, timeElapsed, '0');
+                testCurrentRate(1, initialRate, multiFactor, timeElapsed, '0');
+                testCurrentRate(2, initialRate, multiFactor, timeElapsed, '0');
+                testCurrentRate(3, initialRate, multiFactor, timeElapsed, '0');
+                testCurrentRate(4, initialRate, multiFactor, timeElapsed, '0.000000000000000000000000000000000002');
+                testCurrentRate(5, initialRate, multiFactor, timeElapsed, '0.000000000000000000000000000000000002');
             }
         }
     }
 
     for (let a = 1; a <= 100; a++) {
         const initialRate = new Decimal(a).mul(1234.5678);
-        testConfiguration("initialRate", initialRate, initialRateEncoded, initialRateDecoded, "0", "0.00000000000002");
+        testConfiguration('initialRate', initialRate, initialRateEncoded, initialRateDecoded, '0', '0.00000000000002');
     }
 
     for (let b = 1; b <= 100; b++) {
         const multiFactor = new Decimal(b).mul(0.00001234);
-        testConfiguration("multiFactor", multiFactor, multiFactorEncoded, multiFactorDecoded, "0", "0.0000002");
+        testConfiguration('multiFactor', multiFactor, multiFactorEncoded, multiFactorDecoded, '0', '0.0000002');
     }
 
     for (let a = -28; a <= 28; a++) {
         const initialRate = new Decimal(10).pow(a);
-        testConfiguration("initialRate", initialRate, initialRateEncoded, initialRateDecoded, "0.0000000000000005", "0.00000000000002");
+        testConfiguration('initialRate', initialRate, initialRateEncoded, initialRateDecoded, '0.0000000000000005', '0.00000000000002');
     }
 
     for (let b = -14; b <= -1; b++) {
         const multiFactor = new Decimal(10).pow(b);
-        testConfiguration("multiFactor", multiFactor, multiFactorEncoded, multiFactorDecoded, "0.000000000000004", "0.00000007");
+        testConfiguration('multiFactor', multiFactor, multiFactorEncoded, multiFactorDecoded, '0.000000000000004', '0.00000007');
     }
 });

--- a/test/carbon/accuracy/gradient_strategies.ts
+++ b/test/carbon/accuracy/gradient_strategies.ts
@@ -131,7 +131,7 @@ function testConfiguration(
     });
 }
 
-describe.only('Gradient strategies accuracy stress test', () => {
+describe('Gradient strategies accuracy stress test', () => {
     before(async () => {
         contract = await Contracts.TestTrade.deploy();
     });

--- a/test/carbon/accuracy/gradient_strategies.ts
+++ b/test/carbon/accuracy/gradient_strategies.ts
@@ -136,7 +136,7 @@ function testConfiguration(
 }
 
 function testExp(n: number, d: number, maxError: string) {
-    it(`exp(${n} / ${d})`, async () => {
+    it(`testExp(${n} / ${d})`, async () => {
         const f = new Decimal(n).div(d);
         const funcCall = contract.exp(DecToBn(f.mul(EXP_ONE).floor()));
         if (f.lt(MAX_VAL.div(EXP_ONE))) {

--- a/test/carbon/accuracy/gradient_strategies.ts
+++ b/test/carbon/accuracy/gradient_strategies.ts
@@ -31,7 +31,7 @@ function decode(value: BigNumber, shift: number) {
     const exponent = value.shr(shift).toNumber();
     const data = BnToDec(mantissa.shl(exponent));
     const factor = new Decimal(2).pow(shift);
-    return data.div(factor)
+    return data.div(factor);
 }
 
 function initialRateEncoded(value: Decimal) {
@@ -82,7 +82,7 @@ function testCurrentRate(
     timeElapsed: Decimal,
     maxError: string
 ) {
-    it(`testCurrentRate: gradientType, initialRate, multiFactor, timeElapsed = ${[gradientType, initialRate, multiFactor, timeElapsed]}`, async () => {
+    it(`testCurrentRate: gradientType,initialRate,multiFactor,timeElapsed = ${[gradientType, initialRate, multiFactor, timeElapsed]}`, async () => {
         const rEncoded = initialRateEncoded(initialRate);
         const mEncoded = multiFactorEncoded(multiFactor);
         const rDecoded = initialRateDecoded(rEncoded);

--- a/test/carbon/accuracy/gradient_strategies.ts
+++ b/test/carbon/accuracy/gradient_strategies.ts
@@ -86,7 +86,7 @@ function testCurrentRate(
         const funcCall = contract.calcCurrentRate(gradientType, rEncoded, mEncoded, DecToBn(timeElapsed));
         if (expected.isFinite() && expected.isPositive()) {
             const retVal = await funcCall;
-            const actual = BnToDec(retVal[0]).div(BnToDec(retVal[1]))
+            const actual = BnToDec(retVal[0]).div(BnToDec(retVal[1]));
             if (!actual.eq(expected)) {
                 const error = actual.div(expected).sub(1).abs();
                 expect(error.lte(maxError)).to.be.equal(

--- a/test/carbon/accuracy/gradient_strategies.ts
+++ b/test/carbon/accuracy/gradient_strategies.ts
@@ -12,6 +12,9 @@ const M_SHIFT = 24;
 const ONE = new Decimal(1);
 const TWO = new Decimal(2);
 
+const EXP_ONE = new Decimal(2).pow(127);
+const MAX_VAL = new Decimal(2).pow(131);
+
 const BnToDec = (x: BigNumber) => new Decimal(x.toString());
 const DecToBn = (x: Decimal) => BigNumber.from(x.toFixed());
 
@@ -132,6 +135,33 @@ function testConfiguration(
     });
 }
 
+function testExp(n: number, d: number, maxError: string) {
+    it(`exp(${n} / ${d})`, async () => {
+        const f = new Decimal(n).div(d);
+        const funcCall = contract.exp(DecToBn(f.mul(EXP_ONE).floor()));
+        if (f.lt(MAX_VAL.div(EXP_ONE))) {
+            const actual = BnToDec(await funcCall);
+            const expected = f.exp().mul(EXP_ONE);
+            if (!actual.eq(expected)) {
+                expect(actual.lt(expected)).to.be.equal(
+                    true,
+                    `\n- expected = ${expected.toFixed()}` +
+                    `\n- actual   = ${actual.toFixed()}`
+                );
+                const error = actual.div(expected).sub(1).abs();
+                expect(error.lte(maxError)).to.be.equal(
+                    true,
+                    `\n- expected = ${expected.toFixed()}` +
+                    `\n- actual   = ${actual.toFixed()}` +
+                    `\n- error    = ${error.toFixed()}`
+                );
+            }
+        } else {
+            await expect(funcCall).to.revertedWithError('ExpOverflow');
+        }
+    });
+}
+
 describe('Gradient strategies accuracy stress test', () => {
     before(async () => {
         contract = await Contracts.TestTrade.deploy();
@@ -159,7 +189,7 @@ describe('Gradient strategies accuracy stress test', () => {
                 const initialRate = new Decimal(10).pow(a);
                 const multiFactor = new Decimal(10).pow(b);
                 const timeElapsed = Decimal.min(
-                    TWO.pow(4).div(multiFactor).sub(1).ceil(),
+                    MAX_VAL.div(EXP_ONE).div(multiFactor).sub(1).ceil(),
                     TWO.pow(25).sub(1)
                 ).mul(c).div(10).ceil();
                 testCurrentRate(0, initialRate, multiFactor, timeElapsed, '0');
@@ -190,5 +220,25 @@ describe('Gradient strategies accuracy stress test', () => {
     for (let b = -14; b <= -1; b++) {
         const multiFactor = new Decimal(10).pow(b);
         testConfiguration('multiFactor', multiFactor, multiFactorEncoded, multiFactorDecoded, '0.000000000000004', '0.00000007');
+    }
+
+    for (let n = 1; n <= 25; n++) {
+        for (let d = 1; d <= 25; d++) {
+            testExp(n, d, '0.000000000000000000000000000000000002');
+        }
+    }
+
+    for (let d = 1000; d <= 1000000000; d *= 10) {
+        for (let n = d - 10; n <= d + 10; n++) {
+            testExp(n, d, '0.00000000000000000000000000000000000003');
+        }
+    }
+
+    for (let n = 1; n < 1000; n++) {
+        testExp(n, 1000, '0.00000000000000000000000000000000000003');
+    }
+
+    for (let d = 1; d < 1000; d++) {
+        testExp(1, d, '0.00000000000000000000000000000000000002');
     }
 });


### PR DESCRIPTION
Extend the gradient-strategies testing to include:
1. Asserting the accuracy of the strategy configuration (requested parameters vs encoded parameters)
2. Asserting the accuracy of function `calcCurrentRate` with respect to the encoded parameters instead of the requested parameters