### PR TITLE
Increase the life-time of exponential gradient orders

### DIFF
--- a/contracts/utility/Trade.sol
+++ b/contracts/utility/Trade.sol
@@ -9,10 +9,10 @@ library Trade {
     error InitialRateTooHigh();
     error MultiFactorTooHigh();
 
-    uint256 private constant EXP_LN2 = 0x0058b90bfbe8e7bcd5e4f1d9cc01f97b58; // ceil(ln2)
     uint256 private constant EXP_ONE = 0x0080000000000000000000000000000000; // 1
-    uint256 private constant EXP_MID = 0x0800000000000000000000000000000000; // 16
+    uint256 private constant EXP_MID = 0x0400000000000000000000000000000000; // 8
     uint256 private constant EXP_MAX = 0x2cb53f09f05cc627c85ddebfccfeb72758; // ceil(ln2) * 129
+    uint256 private constant EXP_LN2 = 0x0058b90bfbe8e7bcd5e4f1d9cc01f97b58; // ceil(ln2)
 
     uint256 private constant R_ONE = 1 << 48; // = 2 ^ 48
     uint256 private constant M_ONE = 1 << 24; // = 2 ^ 24
@@ -148,11 +148,16 @@ library Trade {
         }
     }
 
+    /**
+     * @dev Ensure a finite positive rate
+     */
     function sub(uint256 one, uint256 mt) internal pure returns (uint256) {
         unchecked {
             if (one <= mt) {
+                // non-finite or non-positive
                 revert InvalidRate();
             }
+            // finite and positive
             return one - mt;
         }
     }
@@ -186,7 +191,7 @@ library Trade {
 
     /**
      * @dev Compute e ^ (x / EXP_ONE) * EXP_ONE
-     * Input range: 0 <= x <= EXP_MID - 1
+     * Input range: 0 <= x <= EXP_ONE * 16 - 1
      * Detailed description:
      * - Rewrite the input as a sum of binary exponents and a single residual r, as small as possible
      * - The exponentiation of each binary exponent is given (pre-calculated)

--- a/contracts/utility/Trade.sol
+++ b/contracts/utility/Trade.sol
@@ -175,7 +175,7 @@ library Trade {
     function exp(uint256 x) internal pure returns (uint256) {
         unchecked {
             if (x < EXP_MID) {
-                return _exp(x);
+                return _exp(x); // slightly more accurate
             }
             if (x < EXP_MAX) {
                 return _exp(x % EXP_LN2) << (x / EXP_LN2);

--- a/test/carbon/accuracy/gradient_strategies.ts
+++ b/test/carbon/accuracy/gradient_strategies.ts
@@ -222,6 +222,20 @@ describe('Gradient strategies accuracy stress test', () => {
         }
     }
 
+    for (const a of [-27, -10, 0, 10, 27]) {
+        for (const b of [-14, -9, -6, -1]) {
+            for (const c of [19, 24, 29]) {
+                const initialRate = new Decimal(10).pow(a);
+                const multiFactor = new Decimal(10).pow(b);
+                const timeElapsed = new Decimal(2).pow(c).sub(1);
+                testCurrentRate(0, initialRate, multiFactor, timeElapsed, '0.0000000000000000000000000000000000000000003');
+                testCurrentRate(1, initialRate, multiFactor, timeElapsed, '0');
+                testCurrentRate(2, initialRate, multiFactor, timeElapsed, '0');
+                testCurrentRate(3, initialRate, multiFactor, timeElapsed, '0');
+            }
+        }
+    }
+
     for (let a = 1; a <= 100; a++) {
         const initialRate = new Decimal(a).mul(1234.5678);
         testConfiguration('initialRate', initialRate, initialRateEncoded, initialRateDecoded, '0', '0.00000000000002');

--- a/test/carbon/accuracy/gradient_strategies.ts
+++ b/test/carbon/accuracy/gradient_strategies.ts
@@ -13,7 +13,6 @@ const ONE = new Decimal(1);
 const TWO = new Decimal(2);
 
 const EXP_ONE = TWO.pow(127);
-const EXP_MID = EXP_ONE.mul(16);
 const EXP_MAX = EXP_ONE.mul(TWO.ln()).ceil().mul(129);
 
 const BnToDec = (x: BigNumber) => new Decimal(x.toString());
@@ -138,11 +137,10 @@ function testConfiguration(
 
 function testExp(n: number, d: number, maxError: string) {
     it(`testExp(${n} / ${d})`, async () => {
-        const f = new Decimal(n).div(d);
-        const x = f.mul(EXP_ONE).floor();
+        const x = EXP_ONE.mul(n).div(d).floor();
         if (x.lt(EXP_MAX)) {
             const actual = BnToDec(await contract.exp(DecToBn(x)));
-            const expected = f.exp().mul(EXP_ONE);
+            const expected = x.div(EXP_ONE).exp().mul(EXP_ONE);
             if (!actual.eq(expected)) {
                 expect(actual.lt(expected)).to.be.equal(
                     true,
@@ -190,15 +188,15 @@ describe('Gradient strategies accuracy stress test', () => {
                 const initialRate = new Decimal(10).pow(a);
                 const multiFactor = new Decimal(10).pow(b);
                 const timeElapsed = Decimal.min(
-                    EXP_MID.div(EXP_ONE).div(multiFactor).sub(1).ceil(),
+                    TWO.pow(4).div(multiFactor).sub(1).ceil(),
                     TWO.pow(25).sub(1)
                 ).mul(c).div(10).ceil();
                 testCurrentRate(0, initialRate, multiFactor, timeElapsed, '0');
                 testCurrentRate(1, initialRate, multiFactor, timeElapsed, '0');
                 testCurrentRate(2, initialRate, multiFactor, timeElapsed, '0');
                 testCurrentRate(3, initialRate, multiFactor, timeElapsed, '0');
-                testCurrentRate(4, initialRate, multiFactor, timeElapsed, '0.000000000000000000000000000000000002');
-                testCurrentRate(5, initialRate, multiFactor, timeElapsed, '0.000000000000000000000000000000000002');
+                testCurrentRate(4, initialRate, multiFactor, timeElapsed, '0.00000000000000000000000000000000000006');
+                testCurrentRate(5, initialRate, multiFactor, timeElapsed, '0.00000000000000000000000000000000000006');
             }
         }
     }
@@ -217,7 +215,7 @@ describe('Gradient strategies accuracy stress test', () => {
                 testCurrentRate(2, initialRate, multiFactor, timeElapsed, '0');
                 testCurrentRate(3, initialRate, multiFactor, timeElapsed, '0');
                 testCurrentRate(4, initialRate, multiFactor, timeElapsed, '0.000000000004');
-                testCurrentRate(5, initialRate, multiFactor, timeElapsed, '0.000000000000000000000000000000000002');
+                testCurrentRate(5, initialRate, multiFactor, timeElapsed, '0.0000000000000000000000000000000000003');
             }
         }
     }
@@ -258,18 +256,18 @@ describe('Gradient strategies accuracy stress test', () => {
 
     for (let n = 1; n <= 100; n++) {
         for (let d = 1; d <= 100; d++) {
-            testExp(n, d, '0.000000000000000000000000000000000002');
+            testExp(n, d, '0.0000000000000000000000000000000000003');
         }
     }
 
     for (let d = 1000; d <= 1000000000; d *= 10) {
         for (let n = d - 10; n <= d + 10; n++) {
-            testExp(n, d, '0.00000000000000000000000000000000000003');
+            testExp(n, d, '0.00000000000000000000000000000000000002');
         }
     }
 
     for (let n = 1; n < 1000; n++) {
-        testExp(n, 1000, '0.00000000000000000000000000000000000003');
+        testExp(n, 1000, '0.00000000000000000000000000000000000002');
     }
 
     for (let d = 1; d < 1000; d++) {


### PR DESCRIPTION
Increase the life-time (tradability) of exponential gradient orders by more than x5.5, from less than `16/k` seconds to more than `89/k` seconds, where `k` is the gradient order's multiplication-factor.