### PR TITLE
fix forge tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: v1.3.5 # stable version 09.09.2025
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-56dbd20c7179570c53b6c17ff34daa7273a4ddae
+          version: stable
 
       - name: Install dependencies
         run: pnpm install

--- a/test/forge/CarbonPOL.t.sol
+++ b/test/forge/CarbonPOL.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.19;
 
+import { Vm } from "forge-std/Vm.sol";
+
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 
 import { TestFixture } from "./TestFixture.t.sol";
@@ -88,7 +90,7 @@ contract CarbonPOLTest is TestFixture {
         testCaseParser = new POLTestCaseParser();
     }
 
-    function testShouldBeInitialized() public {
+    function testShouldBeInitialized() public view {
         uint16 version = carbonPOL.version();
         assertEq(version, 2);
     }
@@ -124,12 +126,22 @@ contract CarbonPOLTest is TestFixture {
         carbonPOL.setMarketPriceMultiply(0);
     }
 
-    /// @dev test that setMarketPriceMultiply with the same value should be ignored
-    function testFailShouldIgnoreSettingTheSameMarketPriceMultiply() public {
-        vm.prank(admin);
-        vm.expectEmit(false, false, false, false);
-        emit MarketPriceMultiplyUpdated(MARKET_PRICE_MULTIPLY_DEFAULT, MARKET_PRICE_MULTIPLY_DEFAULT);
+    /// @dev should ignore setting the same MarketPriceMultiply (no events emitted)
+    function testShouldIgnoreSettingTheSameMarketPriceMultiply() public {
+        vm.startPrank(admin);
+
+        // first set establishes the default value
         carbonPOL.setMarketPriceMultiply(MARKET_PRICE_MULTIPLY_DEFAULT);
+
+        // record logs for the redundant call
+        vm.recordLogs();
+        carbonPOL.setMarketPriceMultiply(MARKET_PRICE_MULTIPLY_DEFAULT);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        // ensure no events were emitted
+        assertEq(logs.length, 0, "expected no events to be emitted");
+
+        vm.stopPrank();
     }
 
     /// @dev test that admin should be able to update the market price multiply
@@ -165,12 +177,22 @@ contract CarbonPOLTest is TestFixture {
         carbonPOL.setPriceDecayHalfLife(0);
     }
 
-    /// @dev test that setPriceDecayHalfLife with the same value should be ignored
-    function testFailShouldIgnoreSettingTheSamePriceDecayHalfLife() public {
-        vm.prank(admin);
-        vm.expectEmit(false, false, false, false);
-        emit PriceDecayHalfLifeUpdated(PRICE_DECAY_HALFLIFE_DEFAULT, PRICE_DECAY_HALFLIFE_DEFAULT);
+    /// @dev should ignore setting the same PriceDecayHalfLife (no events emitted)
+    function testShouldIgnoreSettingTheSamePriceDecayHalfLife() public {
+        vm.startPrank(admin);
+
+        // first set establishes the default value
         carbonPOL.setPriceDecayHalfLife(PRICE_DECAY_HALFLIFE_DEFAULT);
+
+        // record logs for the redundant call
+        vm.recordLogs();
+        carbonPOL.setPriceDecayHalfLife(PRICE_DECAY_HALFLIFE_DEFAULT);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        // ensure no events were emitted
+        assertEq(logs.length, 0, "expected no events to be emitted");
+
+        vm.stopPrank();
     }
 
     /// @dev test that admin should be able to update the price decay half-life
@@ -206,12 +228,22 @@ contract CarbonPOLTest is TestFixture {
         carbonPOL.setEthSaleAmount(0);
     }
 
-    /// @dev test that setEthSaleAmount with the same value should be ignored
-    function testFailShouldIgnoreSettingTheSameEthSaleAmount() public {
-        vm.prank(admin);
-        vm.expectEmit(false, false, false, false);
-        emit EthSaleAmountUpdated(ETH_SALE_AMOUNT_DEFAULT, ETH_SALE_AMOUNT_DEFAULT);
+    /// @dev should ignore setting the same EthSaleAmount (no events emitted)
+    function testShouldIgnoreSettingTheSameEthSaleAmount() public {
+        vm.startPrank(admin);
+
+        // first set establishes the default value
         carbonPOL.setEthSaleAmount(ETH_SALE_AMOUNT_DEFAULT);
+
+        // record logs for the redundant call
+        vm.recordLogs();
+        carbonPOL.setEthSaleAmount(ETH_SALE_AMOUNT_DEFAULT);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        // ensure no events were emitted
+        assertEq(logs.length, 0, "expected no events to be emitted");
+
+        vm.stopPrank();
     }
 
     /// @dev test that admin should be able to update the eth sale amount
@@ -247,12 +279,22 @@ contract CarbonPOLTest is TestFixture {
         carbonPOL.setMinEthSaleAmount(0);
     }
 
-    /// @dev test that setMinEthSaleAmount with the same value should be ignored
-    function testFailShouldIgnoreSettingTheSameMinEthSaleAmount() public {
-        vm.prank(admin);
-        vm.expectEmit(false, false, false, false);
-        emit MinEthSaleAmountUpdated(MIN_ETH_SALE_AMOUNT_DEFAULT, MIN_ETH_SALE_AMOUNT_DEFAULT);
+    /// @dev should ignore setting the same MinEthSaleAmount (no events emitted)
+    function testShouldIgnoreSettingTheSameMinEthSaleAmount() public {
+        vm.startPrank(admin);
+
+        // first set establishes the default value
         carbonPOL.setMinEthSaleAmount(MIN_ETH_SALE_AMOUNT_DEFAULT);
+
+        // record logs for the redundant call
+        vm.recordLogs();
+        carbonPOL.setMinEthSaleAmount(MIN_ETH_SALE_AMOUNT_DEFAULT);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        // ensure no events were emitted
+        assertEq(logs.length, 0, "expected no events to be emitted");
+
+        vm.stopPrank();
     }
 
     /// @dev test that admin should be able to update the min eth sale amount
@@ -300,7 +342,7 @@ contract CarbonPOLTest is TestFixture {
      */
 
     /// @dev test trading should be disabled initially for all tokens
-    function testTradingShouldBeDisabledInitially(uint256 i) public {
+    function testTradingShouldBeDisabledInitially(uint256 i) public view {
         // pick one of these tokens to test
         Token[4] memory tokens = [token1, token2, bnt, NATIVE_TOKEN];
         // pick a random number from 0 to 2 for the tokens

--- a/test/forge/CarbonVortex.t.sol
+++ b/test/forge/CarbonVortex.t.sol
@@ -1,6 +1,8 @@
 // // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.19;
 
+import { Vm } from "forge-std/Vm.sol";
+
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
@@ -1109,8 +1111,8 @@ contract CarbonVortexTest is TestFixture {
         carbonVortex.execute(tokens);
     }
 
-    /// @dev test shouldn't emit a trade reset event on execute for tokens which have no fees accumulated
-    function testFailShouldntEmitTradeResetForTokensWhichHaveNoFeesAccumulated() public {
+    /// @dev shouldn't emit TradingReset for tokens which have no fees accumulated
+    function testShouldntEmitTradingResetForTokensWhichHaveNoFeesAccumulated() public {
         vm.startPrank(admin);
 
         // test with these three tokens
@@ -1124,26 +1126,36 @@ contract CarbonVortexTest is TestFixture {
         // set fees for token0 and token2 in the carbon controller
         carbonController.testSetAccumulatedFees(tokens[0], accumulatedFees);
         carbonController.testSetAccumulatedFees(tokens[2], accumulatedFees);
-        // transfer token0 fees to carbon
+
+        // transfer token0 fees to the carbon controller
         tokens[0].safeTransfer(address(carbonController), accumulatedFees);
 
         vm.stopPrank();
 
         vm.startPrank(user1);
-
-        ICarbonVortex.Price memory price = ICarbonVortex.Price({
-            sourceAmount: INITIAL_PRICE_SOURCE_AMOUNT,
-            targetAmount: INITIAL_PRICE_TARGET_AMOUNT
-        });
-
-        // test shouldn't emit TradingReset event for token1
-        vm.expectEmit();
-        emit TradingReset(tokens[1], price);
+        vm.recordLogs();
         carbonVortex.execute(tokens);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bytes32 sig = keccak256("TradingReset(address,(uint128,uint128))");
+        uint256 count = 0;
+
+        // check for any TradingReset events for token1
+        for (uint256 i = 0; i < logs.length; ++i) {
+            if (logs[i].topics.length >= 2 && logs[i].topics[0] == sig) {
+                address token = address(uint160(uint256(logs[i].topics[1])));
+                if (token == Token.unwrap(tokens[1])) {
+                    count++;
+                }
+            }
+        }
+
+        assertEq(count, 0);
+        vm.stopPrank();
     }
 
-    /// @dev test shouldn't emit a trade reset on execute for tokens which are disabled
-    function testFailShouldntEmitTradeResetForTokensWhichAreDisabled() public {
+    /// @dev shouldn't emit TradingReset for tokens which are disabled
+    function testShouldntEmitTradingResetForTokensWhichAreDisabled() public {
         vm.startPrank(admin);
 
         // test with these three tokens
@@ -1158,7 +1170,8 @@ contract CarbonVortexTest is TestFixture {
         for (uint256 i = 0; i < 3; ++i) {
             carbonController.testSetAccumulatedFees(tokens[i], accumulatedFees);
         }
-        // transfer token0 fees to carbon
+
+        // transfer token0 fees to the carbon controller
         token0.safeTransfer(address(carbonController), accumulatedFees);
 
         // disable token1
@@ -1167,47 +1180,59 @@ contract CarbonVortexTest is TestFixture {
         vm.stopPrank();
 
         vm.startPrank(user1);
-
-        ICarbonVortex.Price memory price = ICarbonVortex.Price({
-            sourceAmount: INITIAL_PRICE_SOURCE_AMOUNT,
-            targetAmount: INITIAL_PRICE_TARGET_AMOUNT
-        });
-
-        // test shouldn't emit TradingReset event for token1
-        vm.expectEmit();
-        emit TradingReset(tokens[1], price);
+        vm.recordLogs();
         carbonVortex.execute(tokens);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bytes32 sig = keccak256("TradingReset(address,(uint128,uint128))");
+        uint256 count = 0;
+
+        // check for any TradingReset events for token1
+        for (uint256 i = 0; i < logs.length; ++i) {
+            if (logs[i].topics.length >= 2 && logs[i].topics[0] == sig) {
+                address token = address(uint160(uint256(logs[i].topics[1])));
+                if (token == Token.unwrap(tokens[1])) {
+                    count++;
+                }
+            }
+        }
+
+        assertEq(count, 0);
+        vm.stopPrank();
     }
 
-    /// @dev test execute shouldnt emit a trade reset event for the target token if the final target token is zero
-    function testFailShouldntEmitTradeResetForTheTargetTokenIfTheFinalTargetTokenIsZero() public {
-        // Deploy new Carbon Vortex with the final target token set to the zero address
+    /// @dev shouldn't emit TradingReset for the target token if the final target token is zero
+    function testShouldntEmitTradingResetForTheTargetTokenIfTheFinalTargetTokenIsZero() public {
+        // Deploy new Carbon Vortex with final target token set to zero address
         deployCarbonVortex(address(carbonController), vault, transferAddress, targetToken, Token.wrap(address(0)));
 
         vm.startPrank(admin);
-
-        // test with the target token
         Token[] memory tokens = new Token[](1);
         tokens[0] = targetToken;
-
         uint256 accumulatedFees = 100 ether;
-
-        // set fees in carbon controller
         carbonController.testSetAccumulatedFees(tokens[0], accumulatedFees);
-
         vm.stopPrank();
 
         vm.startPrank(user1);
-
-        ICarbonVortex.Price memory price = ICarbonVortex.Price({
-            sourceAmount: INITIAL_PRICE_SOURCE_AMOUNT,
-            targetAmount: INITIAL_PRICE_TARGET_AMOUNT
-        });
-
-        // test shouldn't emit TradingReset event for the target token
-        vm.expectEmit();
-        emit TradingReset(targetToken, price);
+        vm.recordLogs();
         carbonVortex.execute(tokens);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bytes32 sig = keccak256("TradingReset(address,(uint128,uint128))");
+        uint256 count = 0;
+
+        // check for any target token trading resets
+        for (uint256 i = 0; i < logs.length; ++i) {
+            if (logs[i].topics.length >= 2 && logs[i].topics[0] == sig) {
+                address token = address(uint160(uint256(logs[i].topics[1])));
+                if (token == Token.unwrap(targetToken)) {
+                    count++;
+                }
+            }
+        }
+
+        assertEq(count, 0);
+        vm.stopPrank();
     }
 
     function testShouldRevertOnExecuteIfNoTokensArePassed() public {
@@ -3065,11 +3090,16 @@ contract CarbonVortexTest is TestFixture {
     }
 
     /// @dev test that setRewardsPPM with the same rewards ppm should be ignored
-    function testFailShouldIgnoreSettingTheSameRewardsPPM() public {
-        vm.prank(admin);
-        vm.expectEmit(false, false, false, false);
-        emit RewardsUpdated(REWARDS_PPM_DEFAULT, REWARDS_PPM_DEFAULT);
+    function testShouldIgnoreSettingTheSameRewardsPPM() public {
+        vm.startPrank(admin);
         carbonVortex.setRewardsPPM(REWARDS_PPM_DEFAULT);
+
+        vm.recordLogs();
+        carbonVortex.setRewardsPPM(REWARDS_PPM_DEFAULT);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(logs.length, 0, "expected no events to be emitted");
+        vm.stopPrank();
     }
 
     /// @dev test that admin should be able to update the rewards ppm
@@ -3118,11 +3148,16 @@ contract CarbonVortexTest is TestFixture {
     }
 
     /// @dev test that setPriceResetMultiplier with the same value should be ignored
-    function testFailShouldIgnoreSettingTheSamePriceResetMultiplier() public {
-        vm.prank(admin);
-        vm.expectEmit(false, false, false, false);
-        emit PriceResetMultiplierUpdated(PRICE_RESET_MULTIPLIER_DEFAULT, PRICE_RESET_MULTIPLIER_DEFAULT);
+    function testSettingTheSamePriceResetMultiplierShouldntEmitEvent() public {
+        vm.startPrank(admin);
         carbonVortex.setPriceResetMultiplier(PRICE_RESET_MULTIPLIER_DEFAULT);
+
+        vm.recordLogs();
+        carbonVortex.setPriceResetMultiplier(PRICE_RESET_MULTIPLIER_DEFAULT);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(logs.length, 0, "expected no events to be emitted");
+        vm.stopPrank();
     }
 
     /// @dev test that admin should be able to update the price reset multiplier
@@ -3171,14 +3206,16 @@ contract CarbonVortexTest is TestFixture {
     }
 
     /// @dev test that setMinTokenSaleAmountMultiplier with the same value should be ignored
-    function testFailShouldIgnoreSettingTheSameMinTokenSaleAmountMultiplier() public {
-        vm.prank(admin);
-        vm.expectEmit(false, false, false, false);
-        emit MinTokenSaleAmountMultiplierUpdated(
-            MIN_TOKEN_SALE_AMOUNT_MULTIPLIER_DEFAULT,
-            MIN_TOKEN_SALE_AMOUNT_MULTIPLIER_DEFAULT
-        );
+    function testSettingTheSameMinTokenSaleAmountMultiplierShouldntEmitEvent() public {
+        vm.startPrank(admin);
         carbonVortex.setMinTokenSaleAmountMultiplier(MIN_TOKEN_SALE_AMOUNT_MULTIPLIER_DEFAULT);
+
+        vm.recordLogs();
+        carbonVortex.setMinTokenSaleAmountMultiplier(MIN_TOKEN_SALE_AMOUNT_MULTIPLIER_DEFAULT);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(logs.length, 0, "expected no events to be emitted");
+        vm.stopPrank();
     }
 
     /// @dev test that admin should be able to update the minimum token sale amount multiplier
@@ -3230,11 +3267,16 @@ contract CarbonVortexTest is TestFixture {
     }
 
     /// @dev test that setPriceDecayHalfLife with the same value should be ignored
-    function testFailShouldIgnoreSettingTheSamePriceDecayHalfLife() public {
-        vm.prank(admin);
-        vm.expectEmit(false, false, false, false);
-        emit PriceDecayHalfLifeUpdated(PRICE_DECAY_HALFLIFE_DEFAULT, PRICE_DECAY_HALFLIFE_DEFAULT);
+    function testSettingTheSamePriceDecayHalfLifeShouldntEmitEvent() public {
+        vm.startPrank(admin);
         carbonVortex.setPriceDecayHalfLife(PRICE_DECAY_HALFLIFE_DEFAULT);
+
+        vm.recordLogs();
+        carbonVortex.setPriceDecayHalfLife(PRICE_DECAY_HALFLIFE_DEFAULT);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(logs.length, 0, "expected no events to be emitted");
+        vm.stopPrank();
     }
 
     /// @dev test that admin should be able to update the price decay half-life
@@ -3281,12 +3323,17 @@ contract CarbonVortexTest is TestFixture {
         assertEq(targetTokenPriceDecayHalfLife, targetTokenPriceDecayHalfLifeAfter);
     }
 
-    /// @dev test that setTargetTokenPriceDecayHalfLife with the same value should be ignored
-    function testFailShouldIgnoreSettingTheSameTargetTokenPriceDecayHalfLife() public {
-        vm.prank(admin);
-        vm.expectEmit(false, false, false, false);
-        emit TargetTokenPriceDecayHalfLifeUpdated(PRICE_DECAY_HALFLIFE_DEFAULT, PRICE_DECAY_HALFLIFE_DEFAULT);
+    /// @dev test that setTargetTokenPriceDecayHalfLife with the same value doesn't emit event
+    function testSettingTheSameTargetTokenPriceDecayHalfLifeDoesntEmitEvent() public {
+        vm.startPrank(admin);
         carbonVortex.setTargetTokenPriceDecayHalfLife(PRICE_DECAY_HALFLIFE_DEFAULT);
+
+        vm.recordLogs();
+        carbonVortex.setTargetTokenPriceDecayHalfLife(PRICE_DECAY_HALFLIFE_DEFAULT);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(logs.length, 0, "expected no events to be emitted");
+        vm.stopPrank();
     }
 
     /// @dev test that admin should be able to update the target token price decay half-life
@@ -3330,15 +3377,17 @@ contract CarbonVortexTest is TestFixture {
         assertEq(targetTokenPriceDecayHalfLife, targetTokenPriceDecayHalfLifeAfter);
     }
 
-    /// @dev test that setTargetTokenPriceDecayHalfLifeOnReset with the same value should be ignored
-    function testFailShouldIgnoreSettingTheSameTargetTokenPriceDecayHalfLifeOnReset() public {
-        vm.prank(admin);
-        vm.expectEmit(false, false, false, false);
-        emit TargetTokenPriceDecayHalfLifeUpdated(
-            TARGET_TOKEN_PRICE_DECAY_HALFLIFE_DEFAULT,
-            TARGET_TOKEN_PRICE_DECAY_HALFLIFE_DEFAULT
-        );
+    /// @dev test that setTargetTokenPriceDecayHalfLifeOnReset with the same value shouldn't emit event
+    function testSettingTheSameTargetTokenPriceDecayHalfLifeOnResetShouldntEmitEvent() public {
+        vm.startPrank(admin);
         carbonVortex.setTargetTokenPriceDecayHalfLifeOnReset(TARGET_TOKEN_PRICE_DECAY_HALFLIFE_DEFAULT);
+
+        vm.recordLogs();
+        carbonVortex.setTargetTokenPriceDecayHalfLifeOnReset(TARGET_TOKEN_PRICE_DECAY_HALFLIFE_DEFAULT);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(logs.length, 0, "expected no events to be emitted");
+        vm.stopPrank();
     }
 
     /// @dev test that admin should be able to update the target token price decay half-life on reset
@@ -3382,12 +3431,17 @@ contract CarbonVortexTest is TestFixture {
         assertEq(transferAddressBefore, transferAddressAfter);
     }
 
-    /// @dev test that setTransferAddress with the same address should be ignored (using fail test)
-    function testFailShouldIgnoreSettingTheSameTransferAddress() public {
-        vm.prank(admin);
-        vm.expectEmit(false, false, false, false);
-        emit TransferAddressUpdated(transferAddress, transferAddress);
+    /// @dev test that setTransferAddress with the same address shouldn't emit event
+    function testSettingTheSameTransferAddressShouldntEmitEvent() public {
+        vm.startPrank(admin);
         carbonVortex.setTransferAddress(transferAddress);
+
+        vm.recordLogs();
+        carbonVortex.setTransferAddress(transferAddress);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(logs.length, 0, "expected no events to be emitted");
+        vm.stopPrank();
     }
 
     /// @dev test that admin should be able to update the transfer address
@@ -3436,15 +3490,16 @@ contract CarbonVortexTest is TestFixture {
     }
 
     /// @dev test that setMinTargetTokenSaleAmount with the same value should be ignored
-    function testFailShouldIgnoreSettingTheSameMinTargetTokenSaleAmount() public {
-        vm.prank(admin);
-        vm.expectEmit(false, false, false, false);
-        emit MinTokenSaleAmountUpdated(
-            targetToken,
-            MIN_TARGET_TOKEN_SALE_AMOUNT_DEFAULT,
-            MIN_TARGET_TOKEN_SALE_AMOUNT_UPDATED
-        );
+    function testSettingTheSameMinTargetTokenSaleAmountShouldntEmitEvent() public {
+        vm.startPrank(admin);
         carbonVortex.setMinTargetTokenSaleAmount(MIN_TARGET_TOKEN_SALE_AMOUNT_DEFAULT);
+
+        vm.recordLogs();
+        carbonVortex.setMinTargetTokenSaleAmount(MIN_TARGET_TOKEN_SALE_AMOUNT_DEFAULT);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(logs.length, 0, "expected no events to be emitted");
+        vm.stopPrank();
     }
 
     /// @dev test that admin should be able to update the min target token sale amount
@@ -3497,14 +3552,16 @@ contract CarbonVortexTest is TestFixture {
     }
 
     /// @dev test that setMaxTargetTokenSaleAmount with the same value should be ignored
-    function testFailShouldIgnoreSettingTheSameMaxTargetTokenSaleAmount() public {
-        vm.prank(admin);
-        vm.expectEmit(false, false, false, false);
-        emit MaxTargetTokenSaleAmountUpdated(
-            MAX_TARGET_TOKEN_SALE_AMOUNT_DEFAULT,
-            MAX_TARGET_TOKEN_SALE_AMOUNT_DEFAULT
-        );
+    function testSettingTheSameMaxTargetTokenSaleAmountShouldntEmitEvent() public {
+        vm.startPrank(admin);
         carbonVortex.setMaxTargetTokenSaleAmount(MAX_TARGET_TOKEN_SALE_AMOUNT_DEFAULT);
+
+        vm.recordLogs();
+        carbonVortex.setMaxTargetTokenSaleAmount(MAX_TARGET_TOKEN_SALE_AMOUNT_DEFAULT);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(logs.length, 0, "expected no events to be emitted");
+        vm.stopPrank();
     }
 
     /// @dev test that admin should be able to update the max target token sale amount

--- a/test/forge/POLTestCaseParser.t.sol
+++ b/test/forge/POLTestCaseParser.t.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.19;
 
 import { Test } from "forge-std/Test.sol";
 import { stdJson } from "forge-std/StdJson.sol";
-
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 
 import { ICarbonPOL } from "../../contracts/pol/CarbonPOL.sol";
@@ -35,7 +34,6 @@ contract POLTestCaseParser is Test {
         string memory path = "./test/helpers/data/polPricingTestData.json";
         string memory json = vm.readFile(path);
         testCases = parseTestCases(json, "testCase");
-
         return testCases;
     }
 
@@ -67,34 +65,28 @@ contract POLTestCaseParser is Test {
         string memory json,
         string memory templateName
     ) private pure returns (TestCase[] memory testCases) {
-        string memory initialParseString = string.concat("$.", templateName);
+        string memory base = string.concat("$.", templateName);
 
-        // read the test case length
-        string[] memory testCaseString = vm.parseJsonStringArray(json, initialParseString);
-        uint256 testCaseLength = testCaseString.length;
-
-        initialParseString = string.concat(initialParseString, "[");
+        // read the test case count
+        uint256 testCaseLength = vm.parseJsonUint(json, "$.testCaseCount");
 
         // initialize test cases array
         testCases = new TestCase[](testCaseLength);
 
+        // base for indexed lookups
+        string memory baseIdx = string.concat(base, "[");
+
         for (uint256 i = 0; i < testCaseLength; ++i) {
             // get the correct testCase index to parse
-            string memory parseString = string.concat(initialParseString, Strings.toString(i));
+            string memory parseString = string.concat(baseIdx, Strings.toString(i));
 
             // Decode the initial price
             testCases[i].initialPrice = parseInitialPrice(json, parseString);
 
             // Decode the different prices at each timestamp
+            uint256 tokenPriceLen = vm.parseJsonUint(json, string.concat(parseString, "].tokenPriceAtTimestampsCount"));
 
-            // read the timestamp case length
-            string[] memory tokenPriceString = vm.parseJsonStringArray(
-                json,
-                string.concat(parseString, "].tokenPriceAtTimestamps")
-            );
-            uint256 tokenPriceLen = tokenPriceString.length;
-
-            // initialize token price at timestamp string length
+            // initialize token price at timestamp array
             PriceAtTimestamp[] memory pricesAtTimestamp = new PriceAtTimestamp[](tokenPriceLen);
 
             // fill in the token price at timestamp
@@ -103,6 +95,8 @@ contract POLTestCaseParser is Test {
                 string memory fullParseString = string.concat(parseString, "].tokenPriceAtTimestamps[");
                 fullParseString = string.concat(fullParseString, Strings.toString(j));
                 fullParseString = string.concat(fullParseString, "]");
+
+                // Parse the element and decode into stringly struct, then convert to uint
                 bytes memory tokenPriceAtTimestampBytes = json.parseRaw(fullParseString);
                 pricesAtTimestamp[j] = convertPriceAtTimestampToUint(
                     abi.decode(tokenPriceAtTimestampBytes, (PriceAtTimestampString))
@@ -114,21 +108,21 @@ contract POLTestCaseParser is Test {
         return testCases;
     }
 
-    /// @dev convert a price at timestamp struct to uint256
+    /// @dev convert a price at timestamp struct to uints
     function convertPriceAtTimestampToUint(
-        PriceAtTimestampString memory priceAtTimestampString
-    ) private pure returns (PriceAtTimestamp memory priceAtTimestamp) {
+        PriceAtTimestampString memory s
+    ) private pure returns (PriceAtTimestamp memory r) {
         return
             PriceAtTimestamp({
-                timestamp: uint32(stringToUint(priceAtTimestampString.timestamp)),
-                sourceAmount: uint128(stringToUint(priceAtTimestampString.sourceAmount)),
-                targetAmount: uint128(stringToUint(priceAtTimestampString.targetAmount))
+                timestamp: uint32(stringToUint(s.timestamp)),
+                sourceAmount: uint128(stringToUint(s.sourceAmount)),
+                targetAmount: uint128(stringToUint(s.targetAmount))
             });
     }
 
     /// @dev helper function to convert a string to uint256
-    function stringToUint(string memory s) private pure returns (uint256 result) {
-        bytes memory b = bytes(s);
+    function stringToUint(string memory m) private pure returns (uint256 result) {
+        bytes memory b = bytes(m);
         result = 0;
         for (uint256 i = 0; i < b.length; i++) {
             uint256 c = uint256(uint8(b[i]));

--- a/test/forge/Strategies.t.sol
+++ b/test/forge/Strategies.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.19;
 
+import { Vm } from "forge-std/Vm.sol";
+
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
@@ -1193,12 +1195,20 @@ contract StrategiesTest is TestFixture {
         carbonController.setTradingFeePPM(PPM_RESOLUTION + 1);
     }
 
-    function testFailShouldIgnoreUpdatingToTheSameTradingFee() public {
+    function testShouldIgnoreUpdatingToTheSameTradingFee() public {
         uint32 tradingFee = carbonController.tradingFeePPM();
-        vm.prank(admin);
-        vm.expectEmit();
-        emit TradingFeePPMUpdated(tradingFee, tradingFee);
-        carbonController.setTradingFeePPM(NEW_TRADING_FEE_PPM);
+
+        vm.startPrank(admin);
+
+        // record logs for the redundant update
+        vm.recordLogs();
+        carbonController.setTradingFeePPM(tradingFee);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        // ensure no events were emitted
+        assertEq(logs.length, 0, "expected no events to be emitted");
+
+        vm.stopPrank();
     }
 
     function testShouldBeAbleToSetAndUpdateTheTradingFee() public {
@@ -1224,18 +1234,22 @@ contract StrategiesTest is TestFixture {
         carbonController.setPairTradingFeePPM(token0, token1, PPM_RESOLUTION + 1);
     }
 
-    function testFailShouldIgnoreUpdatingToTheSamePairTradingFee() public {
+    function testShouldIgnoreUpdatingToTheSamePairTradingFee() public {
         vm.prank(user1);
         // create pair to be able to update the custom trading fee
         carbonController.createPair(token0, token1);
+
         vm.startPrank(admin);
         carbonController.setPairTradingFeePPM(token0, token1, NEW_TRADING_FEE_PPM);
-        vm.expectEmit();
 
-        Token[2] memory sortedTokens = sortTokens(token0, token1);
-
-        emit PairTradingFeePPMUpdated(sortedTokens[0], sortedTokens[1], 0, NEW_TRADING_FEE_PPM);
+        // record logs for the redundant update
+        vm.recordLogs();
         carbonController.setPairTradingFeePPM(token0, token1, NEW_TRADING_FEE_PPM);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        // ensure no events were emitted
+        assertEq(logs.length, 0, "expected no events to be emitted");
+
         vm.stopPrank();
     }
 
@@ -1630,14 +1644,35 @@ contract StrategiesTest is TestFixture {
         vm.stopPrank();
     }
 
-    function testFailSkipsTransfersOfZeroAmount() public {
+    function testSkipsTransfersOfZeroAmount() public {
         vm.startPrank(user1);
 
         Order memory order = generateTestOrder();
         order.y = 0;
-        vm.expectEmit();
-        emit Transfer(user1, address(carbonController), 0);
+
+        vm.recordLogs();
         carbonController.createStrategy(token0, token1, [order, order]);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bytes32 transferTopic = keccak256("Transfer(address,address,uint256)");
+        uint256 zeroErc20Transfers;
+
+        address t0 = Token.unwrap(token0);
+        address t1 = Token.unwrap(token1);
+
+        for (uint256 i = 0; i < logs.length; ++i) {
+            Vm.Log memory log = logs[i];
+
+            // Filter ERC20 Transfer only
+            if (log.topics.length == 3 && log.topics[0] == transferTopic && (log.emitter == t0 || log.emitter == t1)) {
+                uint256 amount = abi.decode(log.data, (uint256));
+                if (amount == 0) {
+                    zeroErc20Transfers++;
+                }
+            }
+        }
+
+        assertEq(zeroErc20Transfers, 0);
 
         vm.stopPrank();
     }
@@ -1693,14 +1728,20 @@ contract StrategiesTest is TestFixture {
         vm.stopPrank();
     }
 
-    function testFailEmitFeeWithdrawalIfAccumulatedFeeAmountIsZero() public {
+    /// @dev should not emit FeesWithdrawn if accumulated fee amount is zero
+    function testShouldNotEmitFeeWithdrawalIfAccumulatedFeeAmountIsZero() public {
         vm.startPrank(admin);
         carbonController.grantRole(carbonController.roleFeesManager(), admin);
 
         uint256 withdrawAmount = 10;
-        vm.expectEmit();
-        emit FeesWithdrawn(token0, admin, withdrawAmount, admin);
+
+        // record logs before attempting withdrawal
+        vm.recordLogs();
         carbonController.withdrawFees(token0, withdrawAmount, admin);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        // ensure no events were emitted
+        assertEq(logs.length, 0, "expected no events to be emitted");
 
         vm.stopPrank();
     }

--- a/test/forge/TestCaseParser.t.sol
+++ b/test/forge/TestCaseParser.t.sol
@@ -47,7 +47,7 @@ contract TestCaseParser is Test {
         string memory sourceSymbol,
         string memory targetSymbol,
         bool byTargetAmount
-    ) public returns (TestCase memory testCase) {
+    ) public view returns (TestCase memory testCase) {
         TestStrategy[] memory strategies;
         TradeAction[] memory tradeActions;
         uint256 sourceAmount;
@@ -82,7 +82,7 @@ contract TestCaseParser is Test {
         string memory targetSymbol,
         bool byTargetAmount,
         bool inverseOrders
-    ) public returns (TestCase memory testCase) {
+    ) public view returns (TestCase memory testCase) {
         TestStrategy[] memory strategies;
         TradeAction[] memory tradeActions;
         uint256 sourceAmount;
@@ -131,7 +131,7 @@ contract TestCaseParser is Test {
         bool byTargetAmount,
         bool equalHighestAndMarginalRate,
         bool inverseOrders
-    ) public returns (TestCase memory testCase) {
+    ) public view returns (TestCase memory testCase) {
         TestStrategy[] memory strategies;
         TradeAction[] memory tradeActions;
         uint256 sourceAmount;
@@ -189,6 +189,7 @@ contract TestCaseParser is Test {
         string memory templateName
     )
         public
+        view
         returns (
             TestStrategy[] memory strategies,
             TradeAction[] memory tradeActions,
@@ -222,33 +223,25 @@ contract TestCaseParser is Test {
         string memory json,
         string memory templateName
     ) private pure returns (TestStrategy[] memory strategies) {
-        string memory initialParseString = string.concat("$.", templateName);
-        initialParseString = string.concat(initialParseString, ".strategies");
+        string memory base = string.concat("$.", templateName);
+        uint256 strategiesLength = vm.parseJsonUint(json, string.concat(base, ".strategiesCount"));
 
-        // read the strategies length
-        string[] memory strategiesString = vm.parseJsonStringArray(json, initialParseString);
-        uint256 strategiesLength = strategiesString.length;
-
-        initialParseString = string.concat(initialParseString, "[");
-
-        // initialize strategies array
         strategies = new TestStrategy[](strategiesLength);
 
+        string memory prefix = string.concat(base, ".strategies[");
         for (uint256 i = 0; i < strategiesLength; ++i) {
-            // get the correct strategy index to parse
-            string memory parseString = string.concat(initialParseString, Strings.toString(i));
+            string memory idx = Strings.toString(i);
 
-            // Parse the orders field into a bytes array
-            bytes memory order0Bytes = json.parseRaw(string.concat(parseString, "].orders[0]"));
-            bytes memory order1Bytes = json.parseRaw(string.concat(parseString, "].orders[1]"));
-            bytes memory expectedOrder0Bytes = json.parseRaw(string.concat(parseString, "].expectedOrders[0]"));
-            bytes memory expectedOrder1Bytes = json.parseRaw(string.concat(parseString, "].expectedOrders[1]"));
+            bytes memory order0Bytes = json.parseRaw(string.concat(prefix, idx, "].orders[0]"));
+            bytes memory order1Bytes = json.parseRaw(string.concat(prefix, idx, "].orders[1]"));
+            bytes memory expectedOrder0Bytes = json.parseRaw(string.concat(prefix, idx, "].expectedOrders[0]"));
+            bytes memory expectedOrder1Bytes = json.parseRaw(string.concat(prefix, idx, "].expectedOrders[1]"));
 
-            // Decode the bytes array into an Order struct
             Order memory order0 = convertOrderStructToUint(abi.decode(order0Bytes, (OrderString)));
             Order memory order1 = convertOrderStructToUint(abi.decode(order1Bytes, (OrderString)));
             Order memory expectedOrder0 = convertOrderStructToUint(abi.decode(expectedOrder0Bytes, (OrderString)));
             Order memory expectedOrder1 = convertOrderStructToUint(abi.decode(expectedOrder1Bytes, (OrderString)));
+
             strategies[i].orders = [order0, order1];
             strategies[i].expectedOrders = [expectedOrder0, expectedOrder1];
         }
@@ -262,33 +255,20 @@ contract TestCaseParser is Test {
         string memory json,
         string memory templateName
     ) private pure returns (TradeAction[] memory tradeActions) {
-        string memory initialParseString = string.concat("$.", templateName);
-        initialParseString = string.concat(initialParseString, ".tradeActions");
+        string memory base = string.concat("$.", templateName);
+        uint256 tradeActionsLength = vm.parseJsonUint(json, string.concat(base, ".tradeActionsCount"));
 
-        // read the trade actions length
-        string[] memory tradeActionsString = vm.parseJsonStringArray(json, initialParseString);
-        uint256 tradeActionsLength = tradeActionsString.length;
-
-        initialParseString = string.concat(initialParseString, "[");
-
-        // initialize trade actions array
         tradeActions = new TradeAction[](tradeActionsLength);
 
+        string memory prefix = string.concat(base, ".tradeActions[");
         for (uint256 i = 0; i < tradeActionsLength; ++i) {
-            // get the correct trade action index to parse
-            string memory parseString = string.concat(initialParseString, Strings.toString(i));
+            string memory idx = Strings.toString(i);
+            bytes memory tradeActionBytes = json.parseRaw(string.concat(prefix, idx, "]"));
 
-            // Parse the trade actions field into bytes format
-            bytes memory tradeActionBytes = json.parseRaw(string.concat(parseString, "]"));
-            // Decode the bytes into an TradeActionIntermediate struct
-            TradeActionIntermediate memory tradeActionIntermediate = abi.decode(
-                tradeActionBytes,
-                (TradeActionIntermediate)
-            );
-            // Format the TradeAction struct properly
+            TradeActionIntermediate memory t = abi.decode(tradeActionBytes, (TradeActionIntermediate));
             tradeActions[i] = TradeAction({
-                strategyId: bytesToUint(tradeActionIntermediate.strategyId),
-                amount: uint128(stringToUint((tradeActionIntermediate.amount)))
+                strategyId: bytesToUint(t.strategyId),
+                amount: uint128(stringToUint(t.amount))
             });
         }
         return tradeActions;

--- a/test/forge/VortexTestCaseParser.t.sol
+++ b/test/forge/VortexTestCaseParser.t.sol
@@ -4,12 +4,13 @@ pragma solidity 0.8.19;
 import { Test } from "forge-std/Test.sol";
 import { stdJson } from "forge-std/StdJson.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
-
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 
 contract VortexTestCaseParser is Test {
     using stdJson for string;
     using SafeCast for uint256;
+
+    error InvalidVortexTestCaseJson();
 
     struct PriceAtTimestamp {
         uint128 sourceAmount;
@@ -31,83 +32,69 @@ contract VortexTestCaseParser is Test {
      * @dev helper function to get test cases by parsing test data json
      */
     function getTestCase() public view returns (TestCase memory testCase) {
-        string memory path = "./test/helpers/data/vortexPricingTestData.json";
+        string memory path = "./test/helpers/data/vortexPricingTestData.json"; // same filename
         string memory json = vm.readFile(path);
         testCase = parseTestCase(json, "testCase");
-
         return testCase;
     }
 
     /**
-     * @dev helper function to parse test data json object to TestCase struct
+     * @dev parse the json object to TestCase[] struct
      */
     function parseTestCase(
         string memory json,
         string memory templateName
     ) private pure returns (TestCase memory testCases) {
-        string memory initialParseString = string.concat("$.", templateName);
+        string memory base = string.concat("$.", templateName);
 
-        // read the test case length
-        string[] memory testCaseString = vm.parseJsonStringArray(json, initialParseString);
-        uint256 testCaseLength = testCaseString.length;
-
-        initialParseString = string.concat(initialParseString, "[");
-
-        for (uint256 i = 0; i < testCaseLength; ++i) {
-            // get the correct testCase index to parse
-            string memory parseString = string.concat(initialParseString, Strings.toString(i));
-
-            // Decode the different prices at each timestamp
-
-            // read the timestamp case length
-            string[] memory tokenPriceString = vm.parseJsonStringArray(
-                json,
-                string.concat(parseString, "].tokenPriceAtTimestamps")
-            );
-            uint256 tokenPriceLen = tokenPriceString.length;
-
-            // initialize token price at timestamp string length
-            PriceAtTimestamp[] memory pricesAtTimestamp = new PriceAtTimestamp[](tokenPriceLen);
-
-            // fill in the token price at timestamp
-            for (uint256 j = 0; j < tokenPriceLen; ++j) {
-                // Parse the token price field into a bytes array
-                string memory fullParseString = string.concat(parseString, "].tokenPriceAtTimestamps[");
-                fullParseString = string.concat(fullParseString, Strings.toString(j));
-                fullParseString = string.concat(fullParseString, "]");
-                bytes memory tokenPriceAtTimestampBytes = json.parseRaw(fullParseString);
-                pricesAtTimestamp[j] = convertPriceAtTimestampToUint(
-                    abi.decode(tokenPriceAtTimestampBytes, (PriceAtTimestampString))
-                );
-            }
-
-            testCases.pricesAtTimestamp = pricesAtTimestamp;
+        uint256 testCaseLength = vm.parseJsonUint(json, "$.testCaseCount");
+        if (testCaseLength < 1) {
+            revert InvalidVortexTestCaseJson();
         }
+
+        // Build the base path for testCase[0]
+        string memory parseString = string.concat(base, "[0");
+
+        // Read per-test-case count for tokenPriceAtTimestamps
+        uint256 tokenPriceLen = vm.parseJsonUint(json, string.concat(parseString, "].tokenPriceAtTimestampsCount"));
+
+        // Initialize output array
+        PriceAtTimestamp[] memory pricesAtTimestamp = new PriceAtTimestamp[](tokenPriceLen);
+
+        // Fill elements
+        for (uint256 j = 0; j < tokenPriceLen; ++j) {
+            string memory fullParseString = string.concat(parseString, "].tokenPriceAtTimestamps[");
+            fullParseString = string.concat(fullParseString, Strings.toString(j));
+            fullParseString = string.concat(fullParseString, "]");
+
+            bytes memory tokenPriceAtTimestampBytes = json.parseRaw(fullParseString);
+            pricesAtTimestamp[j] = convertPriceAtTimestampToUint(
+                abi.decode(tokenPriceAtTimestampBytes, (PriceAtTimestampString))
+            );
+        }
+
+        testCases.pricesAtTimestamp = pricesAtTimestamp;
         return testCases;
     }
 
-    /// @dev convert a price at timestamp struct to uint256
+    /// @dev convert a price at timestamp struct to numeric types
     function convertPriceAtTimestampToUint(
-        PriceAtTimestampString memory priceAtTimestampString
-    ) private pure returns (PriceAtTimestamp memory priceAtTimestamp) {
+        PriceAtTimestampString memory s
+    ) private pure returns (PriceAtTimestamp memory r) {
         return
             PriceAtTimestamp({
-                timestamp: stringToUint(priceAtTimestampString.timestamp).toUint32(),
-                sourceAmount: stringToUint(priceAtTimestampString.sourceAmount).toUint128(),
-                targetAmount: stringToUint(priceAtTimestampString.targetAmount).toUint128()
+                timestamp: stringToUint(s.timestamp).toUint32(),
+                sourceAmount: stringToUint(s.sourceAmount).toUint128(),
+                targetAmount: stringToUint(s.targetAmount).toUint128()
             });
     }
 
-    /// @dev helper function to convert a string to uint256
-    function stringToUint(string memory s) private pure returns (uint256 result) {
-        bytes memory b = bytes(s);
-        result = 0;
+    /// @dev parse a decimal string to uint256
+    function stringToUint(string memory m) private pure returns (uint256 result) {
+        bytes memory b = bytes(m);
         for (uint256 i = 0; i < b.length; i++) {
             uint256 c = uint256(uint8(b[i]));
-            if (c >= 48 && c <= 57) {
-                result = result * 10 + (c - 48);
-            }
+            if (c >= 48 && c <= 57) result = result * 10 + (c - 48);
         }
-        return result;
     }
 }

--- a/test/forge/Voucher.t.sol
+++ b/test/forge/Voucher.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 pragma solidity 0.8.19;
 
+import { Vm } from "forge-std/Vm.sol";
+
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 
 import { TestFixture } from "./TestFixture.t.sol";
@@ -46,7 +48,7 @@ contract VoucherTest is TestFixture {
      */
 
     /// @dev test should be initialized properly
-    function testShouldBeInitializedProperly() public {
+    function testShouldBeInitializedProperly() public view {
         uint256 version = voucher.version();
         assertEq(version, 2);
 
@@ -62,7 +64,7 @@ contract VoucherTest is TestFixture {
     }
 
     /// @dev test should return the controller address
-    function testShouldReturnControllerAddress() public {
+    function testShouldReturnControllerAddress() public view {
         assertEq(address(carbonController), voucher.controller());
     }
 
@@ -131,18 +133,26 @@ contract VoucherTest is TestFixture {
         voucher.useGlobalURI(false);
     }
 
-    /// @dev test shouldn't emit UseGlobalURIUpdated if updated with the same value
-    function testFailDoesntEmitUseGlobalURIUpdatedIfAnUpdateWasAttemptedWithSameValue() public {
+    /// @dev shouldn't emit UseGlobalURIUpdated if updated with the same value
+    function testDoesntEmitUseGlobalURIUpdatedIfAnUpdateWasAttemptedWithSameValue() public {
         vm.startPrank(admin);
+
+        // initial set
         voucher.useGlobalURI(true);
-        vm.expectEmit();
-        emit UseGlobalURIUpdated(true);
+
+        // record logs for the redundant call
+        vm.recordLogs();
         voucher.useGlobalURI(true);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        // no events expected
+        assertEq(logs.length, 0, "expected no events to be emitted");
+
         vm.stopPrank();
     }
 
     /// @dev test should support erc721 interface
-    function testShouldSupportERC721Interface() public {
+    function testShouldSupportERC721Interface() public view {
         bytes4 erc721InterfaceId = 0x80ac58cd;
         assertTrue(voucher.supportsInterface(erc721InterfaceId));
     }

--- a/test/helpers/data/polPricingTestData.json
+++ b/test/helpers/data/polPricingTestData.json
@@ -54,7 +54,8 @@
         }
       ],
       "initialPriceSourceAmount": "100",
-      "initialPriceTargetAmount": "100"
+      "initialPriceTargetAmount": "100",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -110,7 +111,8 @@
         }
       ],
       "initialPriceSourceAmount": "100",
-      "initialPriceTargetAmount": "1000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -166,7 +168,8 @@
         }
       ],
       "initialPriceSourceAmount": "100",
-      "initialPriceTargetAmount": "10000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -222,7 +225,8 @@
         }
       ],
       "initialPriceSourceAmount": "100",
-      "initialPriceTargetAmount": "1000000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -278,7 +282,8 @@
         }
       ],
       "initialPriceSourceAmount": "100",
-      "initialPriceTargetAmount": "10000000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -334,7 +339,8 @@
         }
       ],
       "initialPriceSourceAmount": "100",
-      "initialPriceTargetAmount": "100000000000000000000000"
+      "initialPriceTargetAmount": "100000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -390,7 +396,8 @@
         }
       ],
       "initialPriceSourceAmount": "100",
-      "initialPriceTargetAmount": "500000000000000000000000"
+      "initialPriceTargetAmount": "500000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -446,7 +453,8 @@
         }
       ],
       "initialPriceSourceAmount": "100",
-      "initialPriceTargetAmount": "1000000000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -502,7 +510,8 @@
         }
       ],
       "initialPriceSourceAmount": "100",
-      "initialPriceTargetAmount": "5000000000000000000000000"
+      "initialPriceTargetAmount": "5000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -558,7 +567,8 @@
         }
       ],
       "initialPriceSourceAmount": "100",
-      "initialPriceTargetAmount": "10000000000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -614,7 +624,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000",
-      "initialPriceTargetAmount": "100"
+      "initialPriceTargetAmount": "100",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -670,7 +681,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -726,7 +738,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -782,7 +795,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -838,7 +852,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -894,7 +909,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000",
-      "initialPriceTargetAmount": "100000000000000000000000"
+      "initialPriceTargetAmount": "100000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -950,7 +966,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000",
-      "initialPriceTargetAmount": "500000000000000000000000"
+      "initialPriceTargetAmount": "500000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -1006,7 +1023,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -1062,7 +1080,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000",
-      "initialPriceTargetAmount": "5000000000000000000000000"
+      "initialPriceTargetAmount": "5000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -1118,7 +1137,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -1174,7 +1194,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000",
-      "initialPriceTargetAmount": "100"
+      "initialPriceTargetAmount": "100",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -1230,7 +1251,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -1286,7 +1308,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -1342,7 +1365,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -1398,7 +1422,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -1454,7 +1479,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000",
-      "initialPriceTargetAmount": "100000000000000000000000"
+      "initialPriceTargetAmount": "100000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -1510,7 +1536,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000",
-      "initialPriceTargetAmount": "500000000000000000000000"
+      "initialPriceTargetAmount": "500000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -1566,7 +1593,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -1622,7 +1650,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000",
-      "initialPriceTargetAmount": "5000000000000000000000000"
+      "initialPriceTargetAmount": "5000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -1678,7 +1707,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -1734,7 +1764,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000000",
-      "initialPriceTargetAmount": "100"
+      "initialPriceTargetAmount": "100",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -1790,7 +1821,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -1846,7 +1878,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -1902,7 +1935,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -1958,7 +1992,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -2014,7 +2049,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000000",
-      "initialPriceTargetAmount": "100000000000000000000000"
+      "initialPriceTargetAmount": "100000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -2070,7 +2106,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000000",
-      "initialPriceTargetAmount": "500000000000000000000000"
+      "initialPriceTargetAmount": "500000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -2126,7 +2163,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -2182,7 +2220,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000000",
-      "initialPriceTargetAmount": "5000000000000000000000000"
+      "initialPriceTargetAmount": "5000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -2238,7 +2277,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -2294,7 +2334,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000000",
-      "initialPriceTargetAmount": "100"
+      "initialPriceTargetAmount": "100",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -2350,7 +2391,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -2406,7 +2448,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -2462,7 +2505,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -2518,7 +2562,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -2574,7 +2619,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000000",
-      "initialPriceTargetAmount": "100000000000000000000000"
+      "initialPriceTargetAmount": "100000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -2630,7 +2676,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000000",
-      "initialPriceTargetAmount": "500000000000000000000000"
+      "initialPriceTargetAmount": "500000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -2686,7 +2733,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -2742,7 +2790,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000000",
-      "initialPriceTargetAmount": "5000000000000000000000000"
+      "initialPriceTargetAmount": "5000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -2798,7 +2847,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -2854,7 +2904,8 @@
         }
       ],
       "initialPriceSourceAmount": "100000000000000000000000",
-      "initialPriceTargetAmount": "100"
+      "initialPriceTargetAmount": "100",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -2910,7 +2961,8 @@
         }
       ],
       "initialPriceSourceAmount": "100000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -2966,7 +3018,8 @@
         }
       ],
       "initialPriceSourceAmount": "100000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -3022,7 +3075,8 @@
         }
       ],
       "initialPriceSourceAmount": "100000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -3078,7 +3132,8 @@
         }
       ],
       "initialPriceSourceAmount": "100000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -3134,7 +3189,8 @@
         }
       ],
       "initialPriceSourceAmount": "100000000000000000000000",
-      "initialPriceTargetAmount": "100000000000000000000000"
+      "initialPriceTargetAmount": "100000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -3190,7 +3246,8 @@
         }
       ],
       "initialPriceSourceAmount": "100000000000000000000000",
-      "initialPriceTargetAmount": "500000000000000000000000"
+      "initialPriceTargetAmount": "500000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -3246,7 +3303,8 @@
         }
       ],
       "initialPriceSourceAmount": "100000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -3302,7 +3360,8 @@
         }
       ],
       "initialPriceSourceAmount": "100000000000000000000000",
-      "initialPriceTargetAmount": "5000000000000000000000000"
+      "initialPriceTargetAmount": "5000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -3358,7 +3417,8 @@
         }
       ],
       "initialPriceSourceAmount": "100000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -3414,7 +3474,8 @@
         }
       ],
       "initialPriceSourceAmount": "500000000000000000000000",
-      "initialPriceTargetAmount": "100"
+      "initialPriceTargetAmount": "100",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -3470,7 +3531,8 @@
         }
       ],
       "initialPriceSourceAmount": "500000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -3526,7 +3588,8 @@
         }
       ],
       "initialPriceSourceAmount": "500000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -3582,7 +3645,8 @@
         }
       ],
       "initialPriceSourceAmount": "500000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -3638,7 +3702,8 @@
         }
       ],
       "initialPriceSourceAmount": "500000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -3694,7 +3759,8 @@
         }
       ],
       "initialPriceSourceAmount": "500000000000000000000000",
-      "initialPriceTargetAmount": "100000000000000000000000"
+      "initialPriceTargetAmount": "100000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -3750,7 +3816,8 @@
         }
       ],
       "initialPriceSourceAmount": "500000000000000000000000",
-      "initialPriceTargetAmount": "500000000000000000000000"
+      "initialPriceTargetAmount": "500000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -3806,7 +3873,8 @@
         }
       ],
       "initialPriceSourceAmount": "500000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -3862,7 +3930,8 @@
         }
       ],
       "initialPriceSourceAmount": "500000000000000000000000",
-      "initialPriceTargetAmount": "5000000000000000000000000"
+      "initialPriceTargetAmount": "5000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -3918,7 +3987,8 @@
         }
       ],
       "initialPriceSourceAmount": "500000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -3974,7 +4044,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000000000",
-      "initialPriceTargetAmount": "100"
+      "initialPriceTargetAmount": "100",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -4030,7 +4101,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -4086,7 +4158,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -4142,7 +4215,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -4198,7 +4272,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -4254,7 +4329,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000000000",
-      "initialPriceTargetAmount": "100000000000000000000000"
+      "initialPriceTargetAmount": "100000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -4310,7 +4386,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000000000",
-      "initialPriceTargetAmount": "500000000000000000000000"
+      "initialPriceTargetAmount": "500000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -4366,7 +4443,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -4422,7 +4500,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000000000",
-      "initialPriceTargetAmount": "5000000000000000000000000"
+      "initialPriceTargetAmount": "5000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -4478,7 +4557,8 @@
         }
       ],
       "initialPriceSourceAmount": "1000000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -4534,7 +4614,8 @@
         }
       ],
       "initialPriceSourceAmount": "5000000000000000000000000",
-      "initialPriceTargetAmount": "100"
+      "initialPriceTargetAmount": "100",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -4590,7 +4671,8 @@
         }
       ],
       "initialPriceSourceAmount": "5000000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -4646,7 +4728,8 @@
         }
       ],
       "initialPriceSourceAmount": "5000000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -4702,7 +4785,8 @@
         }
       ],
       "initialPriceSourceAmount": "5000000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -4758,7 +4842,8 @@
         }
       ],
       "initialPriceSourceAmount": "5000000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -4814,7 +4899,8 @@
         }
       ],
       "initialPriceSourceAmount": "5000000000000000000000000",
-      "initialPriceTargetAmount": "100000000000000000000000"
+      "initialPriceTargetAmount": "100000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -4870,7 +4956,8 @@
         }
       ],
       "initialPriceSourceAmount": "5000000000000000000000000",
-      "initialPriceTargetAmount": "500000000000000000000000"
+      "initialPriceTargetAmount": "500000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -4926,7 +5013,8 @@
         }
       ],
       "initialPriceSourceAmount": "5000000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -4982,7 +5070,8 @@
         }
       ],
       "initialPriceSourceAmount": "5000000000000000000000000",
-      "initialPriceTargetAmount": "5000000000000000000000000"
+      "initialPriceTargetAmount": "5000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -5038,7 +5127,8 @@
         }
       ],
       "initialPriceSourceAmount": "5000000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -5094,7 +5184,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000000000",
-      "initialPriceTargetAmount": "100"
+      "initialPriceTargetAmount": "100",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -5150,7 +5241,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -5206,7 +5298,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -5262,7 +5355,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -5318,7 +5412,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -5374,7 +5469,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000000000",
-      "initialPriceTargetAmount": "100000000000000000000000"
+      "initialPriceTargetAmount": "100000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -5430,7 +5526,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000000000",
-      "initialPriceTargetAmount": "500000000000000000000000"
+      "initialPriceTargetAmount": "500000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -5486,7 +5583,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000000000",
-      "initialPriceTargetAmount": "1000000000000000000000000"
+      "initialPriceTargetAmount": "1000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -5542,7 +5640,8 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000000000",
-      "initialPriceTargetAmount": "5000000000000000000000000"
+      "initialPriceTargetAmount": "5000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     },
     {
       "tokenPriceAtTimestamps": [
@@ -5598,7 +5697,9 @@
         }
       ],
       "initialPriceSourceAmount": "10000000000000000000000000",
-      "initialPriceTargetAmount": "10000000000000000000000000"
+      "initialPriceTargetAmount": "10000000000000000000000000",
+      "tokenPriceAtTimestampsCount": 10
     }
-  ]
+  ],
+  "testCaseCount": 100
 }

--- a/test/helpers/data/tradeTestDataForge.json
+++ b/test/helpers/data/tradeTestDataForge.json
@@ -312,7 +312,9 @@
       }
     ],
     "sourceAmount": "41040000000000000000",
-    "targetAmount": "51283291906"
+    "targetAmount": "51283291906",
+    "strategiesCount": 9,
+    "tradeActionsCount": 9
   },
   "testCaseTemplateByTargetAmount": {
     "byTargetAmount": true,
@@ -627,7 +629,9 @@
       }
     ],
     "sourceAmount": "205408041916",
-    "targetAmount": "164160000000000000000"
+    "targetAmount": "164160000000000000000",
+    "strategiesCount": 9,
+    "tradeActionsCount": 9
   },
   "testCaseTemplateBySourceAmountEqualHighestAndMarginalRate": {
     "byTargetAmount": false,
@@ -968,7 +972,9 @@
       }
     ],
     "sourceAmount": "36000",
-    "targetAmount": "239602"
+    "targetAmount": "239602",
+    "strategiesCount": 10,
+    "tradeActionsCount": 8
   },
   "testCaseTemplateByTargetAmountEqualHighestAndMarginalRate": {
     "byTargetAmount": true,
@@ -1305,6 +1311,8 @@
       }
     ],
     "sourceAmount": "21175",
-    "targetAmount": "28000"
+    "targetAmount": "28000",
+    "strategiesCount": 10,
+    "tradeActionsCount": 7
   }
 }

--- a/test/helpers/data/vortexPricingTestData.json
+++ b/test/helpers/data/vortexPricingTestData.json
@@ -7682,7 +7682,9 @@
           "sourceAmount": "1",
           "targetAmount": "1000000000000"
         }
-      ]
+      ],
+      "tokenPriceAtTimestampsCount": 1536
     }
-  ]
+  ],
+  "testCaseCount": 1
 }


### PR DESCRIPTION
* Fix forge tests so they run with more recent stable foundry version:
 - Replace `testFail` with tests which check event emittal (`getRecordedLogs`)
 - Add `view` and `pure` modifiers where needed to remove warnings
 - Fix test case parser contracts json length counting - for `Trading`, `CarbonPOL` and `CarbonVortex` tests